### PR TITLE
NAM-281 markless comments

### DIFF
--- a/src-electron/constants.ts
+++ b/src-electron/constants.ts
@@ -30,7 +30,7 @@ export const COULD_NOT_READ_COMMENT_LIST = 'Could not read list of comments!';
 export const COULD_NOT_READ_WORKSPACE_LIST = 'Could not read list of working folders!';
 export const NOT_PROVIDED_COMMENT = 'Comment must be provided!';
 
-export const HIGHTLIGHT_HEIGHT = 20;
+export const HIGHLIGHT_HEIGHT = 20;
 export const STUDENT_DIRECTORY_ID_REGEX = /.*\((.+)\)/;
 export const STUDENT_DIRECTORY_REGEX = /(.*), (.*)\((.+)\)/;
 export const STUDENT_DIRECTORY_NO_NAME_REGEX = /(.*),\((.+)\)/;

--- a/src-electron/ipc/assignment.handler.ts
+++ b/src-electron/ipc/assignment.handler.ts
@@ -831,6 +831,7 @@ export function finalizeAssignment(event: IpcMainInvokeEvent, workspaceFolder: s
                         return Promise.reject('Failed to save mark');
                       }
                     }, (error) => {
+                      console.log(error);
                       return Promise.reject('Error annotating marks to PDF ' + fileName + ' [' + error.message + ']');
                     });
                   }

--- a/src-electron/pdf/marking-annotations.ts
+++ b/src-electron/pdf/marking-annotations.ts
@@ -1,20 +1,23 @@
 import {AnnotationFactory} from 'annotpdf';
-import {PageSizes, PDFDocument, PDFPageDrawSVGOptions, rgb, RotationTypes} from 'pdf-lib';
+import {PageSizes, PDFDocument, PDFPageDrawSVGOptions, rgb, PDFPageDrawTextOptions, RotationTypes, StandardFonts} from 'pdf-lib';
 import {IconTypeEnum} from '@shared/info-objects/icon-type.enum';
-import {HIGHTLIGHT_HEIGHT} from '../constants';
+import {HIGHLIGHT_HEIGHT as HIGHTLIGHT_HEIGHT_px} from '../constants';
 import {MarkCoordinate, MarkInfo} from '@shared/info-objects/mark.info';
 import {IconSvgEnum} from '@shared/info-objects/icon-svg.enum';
 import {adjustPointsForResults, hexRgb, RgbaObject, rgbHex} from './pdf-utils';
 import {readFile} from 'fs/promises';
 import {MarkingSubmissionInfo} from '@shared/info-objects/submission.info';
+import { isNil } from 'lodash';
 
 const getRgbScale = (rgbValue: number): number => {
   return +parseFloat(((rgbValue / 255) + '')).toFixed(2);
 };
-const COORD_CONSTANT = (72 / 96);
-// Size of a mark circle
-const CIRCLE_SIZE = 10;
-const CIRCLE_DIAMETER = (CIRCLE_SIZE * 2);
+const COORD_CONSTANT = 72 / 96;
+const HIGHLIGHT_HEIGHT = HIGHTLIGHT_HEIGHT_px * COORD_CONSTANT;
+const CIRCLE_DIAMETER = (37 * COORD_CONSTANT);
+const CIRCLE_SIZE = CIRCLE_DIAMETER / 2;
+const TEXT_ANNOTATION_SIZE = 20 * COORD_CONSTANT;
+const MARK_FONT_SIZE = 12;
 
 interface AnnotationSession {
   data: Uint8Array;
@@ -49,102 +52,77 @@ function rotatePages(session: AnnotationSession, submissionInfo: MarkingSubmissi
   });
 }
 
-/**
- * Rotate the coordinates for the page rotation
- * @param coord
- * @param angle
- * @param width
- * @param height
- */
-function rotate(coord: MarkCoordinate, angle: number, width: number, height: number): MarkCoordinate {
+function rotateCoord(
+  coord: MarkCoordinate,
+  offsetX: number,
+  offsetY: number,
+  angle: number,
+  pageWidth: number,
+  pageHeight: number): MarkCoordinate {
   if (angle === 90) {
     return {
       ...coord,
-      x : coord.y,
-      y : coord.x
+      x : coord.y - offsetY,
+      y : coord.x + offsetX
     };
   } else if (angle === 180) {
     return {
       ...coord,
-      x: width - coord.x,
-      y: coord.y
+      x: pageWidth - coord.x - offsetX,
+      y: coord.y - offsetY
     };
   } else if (angle === 270) {
     return {
       ...coord,
-      x: width - coord.y,
-      y: height - coord.x
+      x: pageWidth - (coord.y - offsetY),
+      y: pageHeight - (coord.x + offsetX)
     };
   } else {
     return {
       ...coord,
-      x: coord.x,
-      y : height - coord.y
+      x: coord.x + offsetX,
+      y : pageHeight - coord.y + offsetY
     };
   }
 }
 
-function rotateHighlight(coord: MarkCoordinate, angle: number, width: number, height: number): number[] {
-  const highlightHeight = (HIGHTLIGHT_HEIGHT * COORD_CONSTANT);
+function rotateBox(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  offsetX: number,
+  offsetY: number,
+  angle: number,
+  pageWidth: number,
+  pageHeight: number): [number, number, number, number] {
   if (angle === 90) {
     return [
-      /*x1 */ coord.y,
-      /*y1 */ coord.x,
-      /*x2 */ coord.y + highlightHeight,
-      /*y2 */ coord.x + coord.width,
+      /*x1 */ y - offsetY,
+      /*y1 */ x + offsetX,
+      /*x2 */ y + h - offsetY,
+      /*y2 */ x + w + offsetX,
     ];
   } else if (angle === 180) {
     return [
-      /*x2 */ width - coord.x - coord.width,
-      /*y2 */ coord.y + highlightHeight,
-      /*x1 */ width - coord.x,
-      /*y1 */ coord.y,
+      /*x1 */ pageWidth - x - w - offsetX,
+      /*y1 */ y - offsetY,
+      /*x2 */ pageWidth - x - offsetX,
+      /*y2 */ y + h - offsetY // Down
     ];
   } else if (angle === 270) {
     return [
-      /*x1 */ width - coord.y - highlightHeight,
-      /*y1 */ height - coord.x,
-      /*x2 */ width - coord.y,
-      /*y2 */ height - coord.x - coord.width
+      /*x1 */ pageWidth  - (y - offsetY),
+      /*y1 */ pageHeight - (x + offsetX),
+      /*x2 */ pageWidth  - (y + h - offsetY),
+      /*y2 */ pageHeight - (x + w + offsetX),
     ];
   } else {
     return [
-      /*x1 */ coord.x,
-      /*y1 */ height - coord.y - highlightHeight,
-      /*x2 */ coord.x + coord.width,
-      /*y2 */ height - coord.y
-    ];
-  }
-}
-
-function rotateCircle(coord: MarkCoordinate, angle: number, width: number, height: number): number[] {
-  if (angle === 90) {
-    return [
-      /*x1 */ coord.y,
-      /*y1 */ coord.x,
-      /*x2 */ coord.y + CIRCLE_DIAMETER,
-      /*y2 */ coord.x + CIRCLE_DIAMETER,
-    ];
-  } else if (angle === 180) {
-    return [
-      /*x2 */ width - coord.x - CIRCLE_DIAMETER,
-      /*y2 */ coord.y + CIRCLE_DIAMETER,
-      /*x1 */ width - coord.x,
-      /*y1 */ coord.y,
-    ];
-  } else if (angle === 270) {
-    return [
-      /*x1 */ width - coord.y - CIRCLE_DIAMETER,
-      /*y1 */ height - coord.x,
-      /*x2 */ width - coord.y,
-      /*y2 */ height - coord.x - CIRCLE_DIAMETER
-    ];
-  } else {
-    return [
-      /*x1 */ coord.x,
-      /*y1 */ height - coord.y - CIRCLE_DIAMETER,
-      /*x2 */ coord.x + CIRCLE_DIAMETER,
-      /*y2 */ height - coord.y
+      /*x1 */ x + offsetX,
+      /*y1 */ pageHeight - y - h + offsetY,
+      /*x2 */ x + w + offsetX,
+      /*y2 */ pageHeight - y  + offsetY
     ];
   }
 }
@@ -169,76 +147,184 @@ function transform(coords: MarkCoordinate): MarkCoordinate {
  */
 function addAnnotations(session: AnnotationSession, marks: MarkInfo[][] = []): Promise<AnnotationSession> {
   const annotationFactory = new AnnotationFactory(session.data);
+  let annotationsAdded = false;
   return PDFDocument.load(session.data).then((pdfDoc) => {
     pdfDoc.getPages().forEach((pdfPage, pageIndex) => {
 
       if (Array.isArray(marks[pageIndex])) {
         marks[pageIndex].forEach(mark => {
-          let coords = transform(mark.coordinates);
+          const coords = transform(mark.coordinates);
           if (mark.iconType === IconTypeEnum.NUMBER) {
 
             session.totalMark += (mark.totalMark) ? mark.totalMark : 0;
-            const annot = annotationFactory.createTextAnnotation({
+            const sectionText = mark.sectionLabel + (isNil(mark.totalMark) ? ' ' : ' = ' + mark.totalMark);
+            annotationFactory.createSquareAnnotation({
               page: pageIndex,
-              rect: rotateCircle(coords, pdfPage.getRotation().angle, pdfPage.getWidth(), pdfPage.getHeight()),
-              contents: mark.comment,
-              author: mark.sectionLabel + ' = ' + mark.totalMark
+              rect: rotateBox(
+                coords.x,
+                coords.y,
+                TEXT_ANNOTATION_SIZE,
+                TEXT_ANNOTATION_SIZE,
+                (CIRCLE_DIAMETER - TEXT_ANNOTATION_SIZE) / 2,
+                (TEXT_ANNOTATION_SIZE / 2) - CIRCLE_SIZE,
+                pdfPage.getRotation().angle,
+                pdfPage.getWidth(),
+                pdfPage.getHeight()
+              ),
+              color: {
+                r: 255,
+                g: 255,
+                b: 255
+              },
+              opacity: 0.0001, // Make it invisible
+              contents: mark.comment || ' ', // TODO check the popup goes missing
+              author: sectionText
             });
-            session.sectionMarks.push(mark.sectionLabel + ' = ' + mark.totalMark);
+            session.sectionMarks.push(sectionText);
+            annotationsAdded = true;
           } else if (mark.iconType === IconTypeEnum.HIGHLIGHT) {
             const colorComponents = mark.colour.match(/(\d\.?)+/g);
+            // const annot = annotationFactory.createSquareAnnotation({
             const annot = annotationFactory.createHighlightAnnotation({
               page: pageIndex,
-              rect: rotateHighlight(coords, pdfPage.getRotation().angle, pdfPage.getWidth(), pdfPage.getHeight()),
-              color: {r: +colorComponents[0], g: +colorComponents[1], b: +colorComponents[2]},
+              rect: rotateBox(
+                coords.x,
+                coords.y,
+                coords.width,
+                HIGHLIGHT_HEIGHT,
+                0,
+                0,
+                pdfPage.getRotation().angle,
+                pdfPage.getWidth(),
+                pdfPage.getHeight()
+              ),
+              color: {
+                r: +colorComponents[0],
+                g: +colorComponents[1],
+                b: +colorComponents[2]
+              },
               opacity: +colorComponents[3],
-              contents: mark.comment || '',
-              author: mark.sectionLabel || ''
+              contents: mark.comment || ' ',
+              author: mark.sectionLabel || ' '
             });
 
             annot.createDefaultAppearanceStream();
+            annotationsAdded = true;
           }
         });
       }
     });
-    session.data = annotationFactory.write();
+    if (annotationsAdded) {
+      session.data = annotationFactory.write();
+    }
     return session;
   });
 }
 
 function addPdfMarks(session: AnnotationSession, marks: MarkInfo[][]): Promise<AnnotationSession> {
   return PDFDocument.load(session.data).then((pdfDoc) => {
+    const font = pdfDoc.embedStandardFont(StandardFonts.CourierBold);
+
     pdfDoc.getPages().forEach((pdfPage, pageIndex) => {
       if (Array.isArray(marks[pageIndex])) {
         marks[pageIndex].forEach(mark => {
-          let coords = transform(mark.coordinates);
-          coords = rotate(coords, pdfPage.getRotation().angle, pdfPage.getWidth(), pdfPage.getHeight());
 
-          if (mark.iconType !== IconTypeEnum.NUMBER) {
-            let colours: RgbaObject = hexRgb('#6F327A');
-            if (mark.colour.startsWith('#')) {
-              colours = hexRgb(mark.colour);
-            } else if (mark.colour.startsWith('rgb')) {
-              colours = hexRgb('#' + rgbHex(mark.colour));
+          if (mark.iconType === IconTypeEnum.HIGHLIGHT) {
+            // Nothing to do here for a highlight
+            return;
+          }
+
+          let coords = transform(mark.coordinates);
+          let colours: RgbaObject = hexRgb('#6F327A');
+          if (mark.colour.startsWith('#')) {
+            colours = hexRgb(mark.colour);
+          } else if (mark.colour.startsWith('rgb')) {
+            colours = hexRgb('#' + rgbHex(mark.colour));
+          }
+          if (mark.iconType ===  IconTypeEnum.NUMBER) {
+
+            if (isNil(mark.totalMark)) {
+
+              coords = rotateCoord(
+                coords,
+                (36 - (24 * 96 / 72)) / 2,
+                (36 - (24 * 96 / 72)) / -2,
+                pdfPage.getRotation().angle,
+                pdfPage.getWidth(),
+                pdfPage.getHeight()
+              );
+              const options: PDFPageDrawSVGOptions = {
+                x: coords.x,
+                y: coords.y,
+                color: rgb(getRgbScale(colours.red), getRgbScale(colours.green), getRgbScale(colours.blue)),
+                rotate: pdfPage.getRotation(),
+              };
+
+              pdfPage.drawSvgPath(IconSvgEnum.NUMBER_SVG, options);
+            } else {
+
+              const circleCoords = rotateCoord(
+                coords,
+                CIRCLE_SIZE,
+                -CIRCLE_SIZE,
+                pdfPage.getRotation().angle,
+                pdfPage.getWidth(),
+                pdfPage.getHeight()
+              );
+              const circleOptions = {
+                x: circleCoords.x,
+                y: circleCoords.y,
+                size: CIRCLE_SIZE,
+                color: rgb(getRgbScale(colours.red), getRgbScale(colours.green), getRgbScale(colours.blue))
+              };
+              pdfPage.drawCircle(circleOptions);
+
+              const w = font.widthOfTextAtSize(mark.totalMark + '', MARK_FONT_SIZE);
+              const h = font.heightAtSize(MARK_FONT_SIZE);
+              coords = rotateCoord(
+                coords,
+                ((CIRCLE_DIAMETER - w) / 2),
+                -h - (CIRCLE_SIZE / 2),
+                pdfPage.getRotation().angle,
+                pdfPage.getWidth(),
+                pdfPage.getHeight()
+              );
+              const markOption: PDFPageDrawTextOptions = {
+                x: coords.x,
+                y: coords.y,
+                size: MARK_FONT_SIZE,
+                font: font,
+                color: rgb(1, 1, 1),
+                rotate: pdfPage.getRotation(),
+              };
+              pdfPage.drawText(mark.totalMark + '', markOption);
             }
+          } else {
+
+            coords = rotateCoord(
+              coords,
+              (36 - (24 * 96 / 72)) / 2,
+              (36 - (24 * 96 / 72)) / -2,
+              pdfPage.getRotation().angle,
+              pdfPage.getWidth(),
+              pdfPage.getHeight());
             const options: PDFPageDrawSVGOptions = {
-              x: coords.x + 4,
+              x: coords.x,
               y: coords.y,
               borderColor: rgb(getRgbScale(colours.red), getRgbScale(colours.green), getRgbScale(colours.blue)),
               color: rgb(getRgbScale(colours.red), getRgbScale(colours.green), getRgbScale(colours.blue)),
-              rotate: {
-                type: RotationTypes.Degrees,
-                angle: pdfPage.getRotation().angle
-              }
+              rotate: pdfPage.getRotation(),
             };
+
             session.totalMark += (mark.totalMark) ? mark.totalMark : 0;
             session.generalMarks += (mark.totalMark) ? mark.totalMark : 0;
+
             if (mark.iconType === IconTypeEnum.FULL_MARK) {
               pdfPage.drawSvgPath(IconSvgEnum.FULL_MARK_SVG, options);
             } else if (mark.iconType === IconTypeEnum.HALF_MARK) {
               pdfPage.drawSvgPath(IconSvgEnum.FULL_MARK_SVG, options);
               pdfPage.drawSvgPath(IconSvgEnum.HALF_MARK_SVG, {
-                x: coords.x + 4,
+                x: coords.x,
                 y: coords.y,
                 borderWidth: 2,
                 borderColor: rgb(getRgbScale(colours.red), getRgbScale(colours.green), getRgbScale(colours.blue)),
@@ -271,7 +357,6 @@ function addResultsPage(session: AnnotationSession, pdfDoc: PDFDocument) {
   let y = 800;
   const xPosition = 25;
   const headerSize = 14;
-  const textSize = 12;
   const borderColor = {red: 0.71, green: 0.71, blue: 0.71};
 
   resultsPage.drawText('Results', {x: resultsPage.getWidth() / 2, y, size: headerSize});
@@ -283,14 +368,14 @@ function addResultsPage(session: AnnotationSession, pdfDoc: PDFDocument) {
       x: xPosition,
       y: 775,
       color: rgb(borderColor.red, borderColor.green, borderColor.blue),
-      size: textSize
+      size: MARK_FONT_SIZE
     });
   y = adjustPointsForResults(y, 15);
 
   for (let i = 0; i < session.sectionMarks.length; i++) {
     y = adjustPointsForResults(y, 15);
-    resultsPage.drawText(session.sectionMarks[i] + '', {x: xPosition, y, size: textSize});
-    resultsPage.drawText('', {x: xPosition, y, size: textSize});
+    resultsPage.drawText(session.sectionMarks[i] + '', {x: xPosition, y, size: MARK_FONT_SIZE});
+    resultsPage.drawText('', {x: xPosition, y, size: MARK_FONT_SIZE});
 
     if (y <= 5) {
       resultsPage = pdfDoc.addPage(PageSizes.A4);
@@ -298,18 +383,18 @@ function addResultsPage(session: AnnotationSession, pdfDoc: PDFDocument) {
     }
   }
   y = adjustPointsForResults(y, 15);
-  resultsPage.drawText('General Marks = ' + session.generalMarks, {x: xPosition, y, size: textSize});
+  resultsPage.drawText('General Marks = ' + session.generalMarks, {x: xPosition, y, size: MARK_FONT_SIZE});
   y = adjustPointsForResults(y, 15);
   resultsPage.drawText('_________________________________________________________________________________', {
     x: xPosition,
     y,
     color: rgb(borderColor.red, borderColor.green, borderColor.blue),
-    size: textSize
+    size: MARK_FONT_SIZE
   });
   y = adjustPointsForResults(y, 15);
-  resultsPage.drawText('', {x: xPosition, y, size: textSize});
+  resultsPage.drawText('', {x: xPosition, y, size: MARK_FONT_SIZE});
   y = adjustPointsForResults(y, 15);
-  resultsPage.drawText('Total = ' + session.totalMark, {x: xPosition, y, size: textSize});
+  resultsPage.drawText('Total = ' + session.totalMark, {x: xPosition, y, size: MARK_FONT_SIZE});
 }
 
 export function annotatePdfFile(filePath: string, submissionInfo: MarkingSubmissionInfo): Promise<{ pdfBytes: Uint8Array, totalMark: number }> {

--- a/src/app/components/assignment-marking-page/assignment-marking-page.component.ts
+++ b/src/app/components/assignment-marking-page/assignment-marking-page.component.ts
@@ -204,14 +204,16 @@ export class AssignmentMarkingPageComponent implements OnInit, AfterViewInit, On
     } else if (mark.iconType === IconTypeEnum.CROSS) {
       mark.totalMark = this.assignmentMarkingComponent.defaultIncorrectMark;
     } else if (mark.iconType === IconTypeEnum.NUMBER) {
-      const config = this.assignmentMarkingComponent.openNewMarkingCommentModal('Marking Comment', '');
+      const config = this.assignmentMarkingComponent.openNewMarkingCommentModal();
       const handelCommentFN = (formData: any) => {
-        mark.totalMark = formData.totalMark;
-        mark.sectionLabel = formData.sectionLabel;
-        mark.comment = formData.markingComment;
-        const updatedMarks: MarkInfo[] = cloneDeep(this.marks);
-        updatedMarks.push(mark);
-        this.assignmentMarkingComponent.savePageMarks(this.pageIndex, updatedMarks).subscribe();
+        if (formData && !formData.removeIcon) {
+          mark.totalMark = formData.totalMark;
+          mark.sectionLabel = formData.sectionLabel;
+          mark.comment = formData.markingComment;
+          const updatedMarks: MarkInfo[] = cloneDeep(this.marks);
+          updatedMarks.push(mark);
+          this.assignmentMarkingComponent.savePageMarks(this.pageIndex, updatedMarks).subscribe();
+        }
       };
       this.appService.createDialog(MarkingCommentModalComponent, config, handelCommentFN);
     }

--- a/src/app/components/assignment-marking/assignment-marking.component.ts
+++ b/src/app/components/assignment-marking/assignment-marking.component.ts
@@ -12,7 +12,7 @@ import {
   ViewContainerRef
 } from '@angular/core';
 import {AssignmentService} from '../../services/assignment.service';
-import {from, mergeMap, Observable, of, Subscription, tap, throwError} from 'rxjs';
+import {from, mergeMap, Observable, Subscription, tap, throwError} from 'rxjs';
 import {ActivatedRoute, Router} from '@angular/router';
 import {AppService} from '../../services/app.service';
 import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
@@ -30,12 +30,7 @@ import {AssignmentMarkingPageComponent} from '../assignment-marking-page/assignm
 import {IRubric} from '@shared/info-objects/rubric.class';
 import {PdfmUtilsService} from '../../services/pdfm-utils.service';
 import {BusyService} from '../../services/busy.service';
-import {
-  MarkingSubmissionInfo,
-  PageSettings,
-  RubricSubmissionInfo,
-  SubmissionInfo
-} from "@shared/info-objects/submission.info";
+import {MarkingSubmissionInfo, PageSettings, SubmissionInfo} from '@shared/info-objects/submission.info';
 
 
 GlobalWorkerOptions.workerSrc = 'pdf.worker.min.js';
@@ -287,7 +282,7 @@ export class AssignmentMarkingComponent implements OnInit, OnDestroy {
     );
   }
 
-  savePageSettings(pageIndex: number, pageSettings: PageSettings): Observable<any>{
+  savePageSettings(pageIndex: number, pageSettings: PageSettings): Observable<any> {
     const originalSubmissionInfo = cloneDeep(this.submissionInfo);
     const markDetails = {
       ...this.submissionInfo,
@@ -405,14 +400,13 @@ export class AssignmentMarkingComponent implements OnInit, OnDestroy {
     this.appService.createDialog(FinaliseMarkingComponent, config);
   }
 
-  openNewMarkingCommentModal(title: string = 'Marking Comment', message: string) {
+  openNewMarkingCommentModal(): MatDialogConfig {
     const config = new MatDialogConfig();
     config.width = '400px';
     config.maxWidth = '500px';
     config.disableClose = true;
     config.data = {
-      title: title,
-      message: message,
+      comment: null
     };
 
     return config;

--- a/src/app/components/file-explorer-modal/file-explorer-modal.component.scss
+++ b/src/app/components/file-explorer-modal/file-explorer-modal.component.scss
@@ -5,18 +5,6 @@
   margin-bottom: 0;
 }
 
-.mat-dialog-content::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-  background: #F5F5F5;
-}
-
-.mat-dialog-content::-webkit-scrollbar-thumb {
-  border-radius: 10px;
-  background: var(--pdf-marker-primary);
-}
-
-
 .example-tree-invisible {
   display: none;
 }

--- a/src/app/components/mark-type-highlight/mark-type-highlight.component.html
+++ b/src/app/components/mark-type-highlight/mark-type-highlight.component.html
@@ -4,7 +4,7 @@
     class="icon-edit"
     matTooltip="Add/Edit Comment"
     (click)="onEdit($event)">
-    chat
+      comment
   </mat-icon>
   </div>
   <div class="highlight" #highlight></div>
@@ -15,7 +15,7 @@
         class="icon-edit"
         matTooltip="Add/Edit Comment"
         (click)="onEdit($event)">
-        chat
+        comment
       </mat-icon>
       <mat-icon
         [style.color]="selectedHighlightColour.preview"

--- a/src/app/components/mark-type-highlight/mark-type-highlight.component.scss
+++ b/src/app/components/mark-type-highlight/mark-type-highlight.component.scss
@@ -21,6 +21,7 @@
     height: 16px;
     width: 16px;
     font-size: 16px;
+    color: var(--pdf-marker-secondary)
   }
 }
 

--- a/src/app/components/mark-type-highlight/mark-type-highlight.component.ts
+++ b/src/app/components/mark-type-highlight/mark-type-highlight.component.ts
@@ -141,13 +141,15 @@ export class MarkTypeHighlightComponent implements OnInit, AfterViewInit, OnDest
     };
 
     const handleCommentFN = (formData: any) => {
-      const updateMark = cloneDeep(this.mark);
-      updateMark.sectionLabel = formData.sectionLabel;
-      updateMark.comment = formData.markingComment;
-      this.assignmentMarkingPageComponent.onMarkChanged(this.index, updateMark).subscribe(() => {
-        this.mark.sectionLabel = updateMark.sectionLabel;
-        this.mark.comment = updateMark.comment;
-      });
+      if (formData && !formData.removeIcon) {
+        const updateMark = cloneDeep(this.mark);
+        updateMark.sectionLabel = formData.sectionLabel;
+        updateMark.comment = formData.markingComment;
+        this.assignmentMarkingPageComponent.onMarkChanged(this.index, updateMark).subscribe(() => {
+          this.mark.sectionLabel = updateMark.sectionLabel;
+          this.mark.comment = updateMark.comment;
+        });
+      }
     };
     this.appService.createDialog(MarkingHighlightModalComponent, config, handleCommentFN);
   }

--- a/src/app/components/mark-type-icon/mark-type-icon.component.html
+++ b/src/app/components/mark-type-icon/mark-type-icon.component.html
@@ -7,7 +7,7 @@
   (cdkDragEnded)="onDragEnded($event)">
 
 
-  <div class="mark-icon-container">
+  <div class="mark-icon-container" [class.hasMark]="mark.totalMark != null">
     <form [formGroup]="iconForm">
       <mat-icon
         *ngIf="mark.iconType !== iconTypeEnum.NUMBER && mark.iconType !== iconTypeEnum.HALF_MARK"
@@ -15,20 +15,25 @@
         {{ mark.iconName }}
       </mat-icon>
       <mat-icon
-        *ngIf="mark.iconType === iconTypeEnum.HALF_MARK" [svgIcon]="mark.iconName"
+        *ngIf="mark.iconType === iconTypeEnum.HALF_MARK"
+        [svgIcon]="mark.iconName"
         [style.color]="mark.colour"
         [style.stroke]="mark.colour"
         [style.stroke-width]="0">
       </mat-icon>
-      <ng-container *ngIf="mark.iconType === iconTypeEnum.NUMBER">
+      <div
+        *ngIf="mark.iconType === iconTypeEnum.NUMBER"
+        class="comment-circle"
+        [style.background]="mark.totalMark == null ? 'transparent' : mark.colour">
         <input
           class="mark-input"
-          [style.background]="mark.colour"
           type="text"
           formControlName="totalMark"
           (mouseleave)="onTotalMarkChange($event)"/>
-        <mat-icon *ngIf="mark.comment" class="pdf-marker-special-icon-attach">attach_file</mat-icon>
-      </ng-container>
+        <mat-icon
+          [style.color]="mark.totalMark == null ? mark.colour : 'var(--pdf-marker-secondary)'"
+          class="pdf-marker-special-icon-attach">comment</mat-icon>
+      </div>
     </form>
   </div>
 

--- a/src/app/components/mark-type-icon/mark-type-icon.component.scss
+++ b/src/app/components/mark-type-icon/mark-type-icon.component.scss
@@ -12,11 +12,18 @@
   }
 }
 
+.pdf-marker-special-icon-attach{
+  width: 16px;
+  height: 16px;
+  font-size: 16px;
+}
 
 .pdf-marker-mark-type-icon-container {
 
   display: flex;
   flex-direction: column;
+
+
 
   .mark-icon-container {
     border: 1px dotted transparent;
@@ -32,18 +39,55 @@
       left: 50%;
       top: 50%;
       transform: translate(-50%, -50%);
-      font-size: 24px;
     }
 
     .mark-input {
+      display: none;
+    }
+
+    .comment-circle {
       width: 34px;
       height: 34px;
       border-radius: 50%;
-      color: #fff;
-      text-align: center;
-      font-weight: 600;
       padding: 0;
-      border: 1px solid;
+      background: transparent;
+    }
+
+    &:not(.hasMark) {
+      .pdf-marker-special-icon-attach {
+        color: #fff;
+        top: 57%;
+        left: 55%;
+
+        height: 24px;
+        width: 24px;
+        font-size: 24px;
+      }
+    }
+
+    &.hasMark{
+
+      .comment-circle {
+        border: 1px solid;
+      }
+
+      .mark-input {
+        display: inline;
+        color: #fff;
+        text-align: center;
+        font-weight: 600;
+        border: none;
+        width: 32px;
+        height: 32px;
+        background: transparent;
+      }
+
+      .pdf-marker-special-icon-attach {
+        text-align: right !important;
+        color: var(--pdf-marker-secondary);
+        left: 36px;
+        top: 5px;
+      }
     }
   }
 
@@ -54,10 +98,13 @@
 
 
 
-      .mark-input{
+      &.hasMark .comment-circle{
         background: none !important;
-        color: #a94442;
         border-color: transparent !important;
+
+        .mark-input{
+          color: #a94442;
+        }
       }
     }
 
@@ -105,15 +152,6 @@
   .mark-icon-container {
   }
 
-  .pdf-marker-special-icon-attach {
-    text-align: right !important;
-    width: 1px !important;
-    height: 1px !important;
-    color: #bebdbe;
-    left: 87% !important;
-    top: 0 !important;
-    transform: translate(-100%)!important;
 
-  }
 }
 

--- a/src/app/components/mark-type-icon/mark-type-icon.component.ts
+++ b/src/app/components/mark-type-icon/mark-type-icon.component.ts
@@ -201,26 +201,30 @@ export class MarkTypeIconComponent implements OnInit, OnDestroy {
     config.width = '400px';
     config.maxWidth = '500px';
     config.data = {
-      markingComment: this.mark.comment,
-      sectionLabel: this.mark.sectionLabel,
-      totalMark: this.mark.totalMark,
+      comment : {
+        markingComment: this.mark.comment,
+        sectionLabel: this.mark.sectionLabel,
+        totalMark: this.mark.totalMark,
+      }
     };
 
     const handleCommentFN = (formData: any) => {
-      const updateMark = cloneDeep(this.mark);
-      updateMark.totalMark = formData.totalMark;
-      updateMark.sectionLabel = formData.sectionLabel;
-      updateMark.comment = formData.markingComment;
+      if (formData) {
+        const updateMark = cloneDeep(this.mark);
+        updateMark.totalMark = formData.totalMark;
+        updateMark.sectionLabel = formData.sectionLabel;
+        updateMark.comment = formData.markingComment;
 
-      if (this.iconForm) {
-        this.iconForm.controls.totalMark.setValue(this.mark.totalMark);
-      }
+        if (this.iconForm) {
+          this.iconForm.controls.totalMark.setValue(this.mark.totalMark);
+        }
 
-      this.assignmentMarkingPageComponent.onMarkChanged(this.index, updateMark).subscribe(() => {
+        this.assignmentMarkingPageComponent.onMarkChanged(this.index, updateMark).subscribe(() => {
           this.mark.totalMark = updateMark.totalMark;
           this.mark.sectionLabel = updateMark.sectionLabel;
           this.mark.comment = updateMark.comment;
-      });
+        });
+      }
     };
     this.appService.createDialog(MarkingCommentModalComponent, config, handleCommentFN);
   }

--- a/src/app/components/marking-comment-modal/marking-comment-modal.component.html
+++ b/src/app/components/marking-comment-modal/marking-comment-modal.component.html
@@ -1,41 +1,80 @@
-<ng-container>
-  <div class="pdf-spacer" style="border: 1px solid #F5F5F5"></div>
+<div mat-dialog-title>
+  <h3><mat-icon style="top: 4px;position: relative;">comment</mat-icon> Comment</h3>
+</div>
+
+
+<mat-dialog-content>
   <form [formGroup]="commentForm">
-    <h1><mat-icon>add_comment</mat-icon> Marking Comment</h1>
-    <mat-divider></mat-divider>
-    <div class="pdf-spacer"></div>
-    <mat-form-field class="settings-halfWidth">
-      <mat-label>Section Title</mat-label>
-      <input formControlName="sectionLabel" id="sectionLabel" #sectionLabel type="text" placeholder="Question/Section ..." matInput required [autocomplete]="false">
-    </mat-form-field><br>
-    <div class="pdf-spacer"></div>
-    <mat-divider></mat-divider>
-    <mat-form-field>
-      <mat-label>Mark:</mat-label>
-      <input  type="number" formControlName="totalMark" id="totalMark" #totalMark placeholder="Mark Value..." matInput required [autocomplete]="false">
-    </mat-form-field><br>
-    <div class="pdf-spacer"></div>
-    <mat-divider></mat-divider>
-    <mat-form-field>
-      <mat-label>Generic Comment:</mat-label>
-      <mat-select formControlName="genericComment" (selectionChange)="appendGenericComment($event)">
-        <mat-option *ngFor="let comment of genericComments" [value]="comment.title">{{comment.title}}</mat-option>
-      </mat-select>
-    </mat-form-field><br>
-    <div class="pdf-spacer"></div>
-    <mat-divider></mat-divider>
-    <mat-form-field style="width:100%">
-      <mat-label>Comment:</mat-label>
-      <textarea formControlName="markingComment" id="markingComment" #markingComment
-                type="text" matInput placeholder="Marking comment to student..."
-                (focusout)="trackCommentCaretPosition(markingComment, $event)"
-                cdkTextareaAutosize cdkAutosizeMinRows="2"></textarea>
-    </mat-form-field>
-    <mat-divider></mat-divider>
-    <div class="pdf-spacer"></div>
-    <div  mat-dialog-actions class="pdf-marker-yes-and-no-confirmation-dialog-actions">
-      <button type="button" class="pdf-marker-yes-and-no-confirmation-dialog-yes" mat-button color="" (click)="onSubmit($event)">Save</button>&nbsp;&nbsp;
-      <button type="button" class="pdf-marker-yes-and-no-confirmation-dialog-no" mat-button color="" (click)="onCancel($event)">Cancel</button>
+
+    <div>
+      <mat-form-field>
+        <mat-label>Section Title</mat-label>
+        <input
+          formControlName="sectionLabel"
+          id="sectionLabel"
+          type="text"
+          placeholder="Question/Section ..."
+          matInput
+          [autocomplete]="false">
+      </mat-form-field>
+    </div>
+
+    <div>
+      <mat-form-field>
+        <mat-label>Comment Type:</mat-label>
+        <mat-select formControlName="commentType">
+          <mat-option
+            *ngFor="let commentType of commentTypes"
+            [value]="commentType">
+            {{commentType}}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+
+    <div *ngIf="commentForm.controls.totalMark">
+      <mat-form-field>
+        <mat-label>Mark:</mat-label>
+        <input
+          type="number"
+          formControlName="totalMark"
+          id="totalMark"
+          placeholder="Mark Value..."
+          matInput
+          [autocomplete]="false">
+      </mat-form-field>
+    </div>
+
+    <div>
+      <mat-form-field>
+        <mat-label>Generic Comment:</mat-label>
+        <mat-select formControlName="genericComment" (selectionChange)="appendGenericComment($event)">
+          <mat-option *ngFor="let comment of genericComments" [value]="comment.title">{{comment.title}}</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+
+    <div>
+      <mat-form-field style="width:100%">
+        <mat-label>Comment:</mat-label>
+        <textarea
+          #markingComment
+          id="markingComment"
+          formControlName="markingComment"
+          type="text"
+          matInput
+          cdkTextareaAutosize
+          cdkAutosizeMinRows="2"
+          placeholder="Marking comment to student..."
+          (focusout)="trackCommentCaretPosition(markingComment, $event)">
+      </textarea>
+      </mat-form-field>
+
     </div>
   </form>
-</ng-container>
+</mat-dialog-content>
+
+<mat-dialog-actions class="pdf-marker-yes-and-no-confirmation-dialog-actions">
+  <button type="button" class="pdf-marker-yes-and-no-confirmation-dialog-yes" mat-button color="" (click)="onSubmit($event)">Save</button>&nbsp;&nbsp;
+  <button type="button" class="pdf-marker-yes-and-no-confirmation-dialog-no" mat-button color="" (click)="onCancel($event)">Cancel</button>
+</mat-dialog-actions>

--- a/src/app/components/marking-highlight-modal/marking-highlight-modal.component.html
+++ b/src/app/components/marking-highlight-modal/marking-highlight-modal.component.html
@@ -1,35 +1,55 @@
-<ng-container>
-  <div class="pdf-spacer" style="border: 1px solid #F5F5F5"></div>
+<div mat-dialog-title>
+  <h3><mat-icon style="top: 4px;position: relative;">comment</mat-icon> Comment</h3>
+</div>
+
+
+
+<mat-dialog-content>
   <form [formGroup]="commentForm">
-    <h1><mat-icon>add_comment</mat-icon> Comment</h1>
-    <mat-divider></mat-divider>
-    <div class="pdf-spacer"></div>
-    <mat-form-field class="settings-halfWidth">
-      <mat-label>Section Title</mat-label>
-      <input formControlName="sectionLabel" id="sectionLabel" #sectionLabel type="text" placeholder="Question/Section ..." matInput required [autocomplete]="false">
-    </mat-form-field><br>
-    <div class="pdf-spacer"></div>
-    <mat-divider></mat-divider>
-    <mat-form-field>
-      <mat-label>Generic Comment:</mat-label>
-      <mat-select formControlName="genericComment" (selectionChange)="appendGenericComment($event)">
-        <mat-option *ngFor="let comment of genericComments" [value]="comment.title">{{comment.title}}</mat-option>
-      </mat-select>
-    </mat-form-field><br>
-    <div class="pdf-spacer"></div>
-    <mat-divider></mat-divider>
-    <mat-form-field style="width:100%">
-      <mat-label>Comment:</mat-label>
-      <textarea formControlName="markingComment" id="markingComment" #markingComment
-                type="text" matInput placeholder="Marking comment to student..."
-                (focusout)="trackCommentCaretPosition(markingComment, $event)"
-                cdkTextareaAutosize cdkAutosizeMinRows="2"></textarea>
-    </mat-form-field>
-    <mat-divider></mat-divider>
-    <div class="pdf-spacer"></div>
-    <div  mat-dialog-actions class="pdf-marker-yes-and-no-confirmation-dialog-actions">
-      <button type="button" class="pdf-marker-yes-and-no-confirmation-dialog-yes" mat-button color="" (click)="onSubmit($event)">Save</button>&nbsp;&nbsp;
-      <button type="button" class="pdf-marker-yes-and-no-confirmation-dialog-no" mat-button color="" (click)="onCancel($event)">Cancel</button>
+
+    <div>
+      <mat-form-field>
+        <mat-label>Section Title</mat-label>
+        <input
+          formControlName="sectionLabel"
+          id="sectionLabel"
+          type="text"
+          placeholder="Question/Section ..."
+          matInput
+          [autocomplete]="false">
+      </mat-form-field>
+    </div>
+
+    <div>
+      <mat-form-field>
+        <mat-label>Generic Comment:</mat-label>
+        <mat-select formControlName="genericComment" (selectionChange)="appendGenericComment($event)">
+          <mat-option *ngFor="let comment of genericComments" [value]="comment.title">{{comment.title}}</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+
+    <div>
+      <mat-form-field style="width:100%">
+        <mat-label>Comment:</mat-label>
+        <textarea
+          #markingComment
+          id="markingComment"
+          formControlName="markingComment"
+          type="text"
+          matInput
+          cdkTextareaAutosize
+          cdkAutosizeMinRows="2"
+          placeholder="Marking comment to student..."
+          (focusout)="trackCommentCaretPosition(markingComment, $event)">
+      </textarea>
+      </mat-form-field>
+
     </div>
   </form>
-</ng-container>
+</mat-dialog-content>
+
+<mat-dialog-actions class="pdf-marker-yes-and-no-confirmation-dialog-actions">
+  <button type="button" class="pdf-marker-yes-and-no-confirmation-dialog-yes" mat-button color="" (click)="onSubmit($event)">Save</button>&nbsp;&nbsp;
+  <button type="button" class="pdf-marker-yes-and-no-confirmation-dialog-no" mat-button color="" (click)="onCancel($event)">Cancel</button>
+</mat-dialog-actions>

--- a/src/app/components/marking-highlight-modal/marking-highlight-modal.component.ts
+++ b/src/app/components/marking-highlight-modal/marking-highlight-modal.component.ts
@@ -1,10 +1,11 @@
-import {Component, Inject, OnInit} from '@angular/core';
+import {Component, Inject, OnDestroy, OnInit} from '@angular/core';
 import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
 import {IComment} from '@shared/info-objects/comment.class';
 import {AppService} from '../../services/app.service';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {CommentService} from '../../services/comment.service';
 import {MatSelectChange} from '@angular/material/select';
+import {isNil} from "lodash";
 
 @Component({
   selector: 'pdf-marker-marking-highlight-modal',
@@ -15,21 +16,10 @@ export class MarkingHighlightModalComponent implements OnInit {
 
 
   commentForm: FormGroup;
-  private title: string;
-
-  private message: string;
 
   private sectionLabel: string;
 
   private markingComment: string;
-
-  readonly yes: boolean = true;
-
-  readonly no: boolean = false;
-
-  private totalMark: number = undefined;
-
-  private  markingCommentObj: any;
 
   genericComments: IComment[] = [];
 
@@ -37,41 +27,33 @@ export class MarkingHighlightModalComponent implements OnInit {
 
   constructor(private appService: AppService,
               private dialogRef: MatDialogRef<MarkingHighlightModalComponent>,
-              @Inject(MAT_DIALOG_DATA) config,
+              @Inject(MAT_DIALOG_DATA) private config,
               private fb: FormBuilder,
               private commentService: CommentService) {
 
     this.initForm();
 
-    this.title = config.title;
-    this.message = config.message;
-    if (config.markingComment) {
-      this.markingComment = config.markingComment;
-      this.commentForm.controls.markingComment.setValue(config.markingComment);
-    }
-    if (config.sectionLabel) {
-      this.sectionLabel = config.sectionLabel;
-      this.commentForm.controls.sectionLabel.setValue(config.sectionLabel);
-    }
-    if (config.totalMark) {
-      this.totalMark = config.totalMark;
-      this.commentForm.controls.totalMark.setValue(config.totalMark);
-    }
 
+  }
+
+  ngOnInit() {
     this.commentService.getCommentDetails().subscribe((comments: IComment[]) => {
       this.genericComments = comments;
     });
 
-    this.markingCommentObj = {
-      sectionLabel: this.commentForm.controls.sectionLabel.value,
-      totalMark: 0,
-      markingComment: this.commentForm.controls.markingComment.value,
-      genericComment: this.commentForm.controls.genericComment.value
-    };
-  }
+    const model: any = {};
 
-  ngOnInit() {
+    if (!isNil(this.config.comment)) {
+      const commentObj = this.config.comment;
+      if (commentObj.markingComment) {
+        model.markingComment = commentObj.markingComment;
+      }
+      if (commentObj.sectionLabel) {
+        model.sectionLabel = commentObj.sectionLabel;
+      }
+    }
 
+    this.commentForm.reset(model);
   }
   private initForm() {
     this.commentForm = this.fb.group({
@@ -83,7 +65,7 @@ export class MarkingHighlightModalComponent implements OnInit {
 
   onCancel($event: MouseEvent) {
     if (this.commentForm.valid) {
-      this.dialogRef.close(this.markingCommentObj);
+      this.dialogRef.close(null);
     } else {
       const markingRemove = {removeIcon: true};
       this.dialogRef.close(markingRemove);
@@ -92,13 +74,14 @@ export class MarkingHighlightModalComponent implements OnInit {
 
   onSubmit($event: MouseEvent) {
     if (this.commentForm.valid) {
-      this.markingCommentObj = {
-        sectionLabel: this.commentForm.controls.sectionLabel.value,
+      const formValue = this.commentForm.value;
+      const markingCommentObj = {
+        sectionLabel: formValue.sectionLabel,
         totalMark: 0,
-        markingComment: this.commentForm.controls.markingComment.value,
-        genericComment: this.commentForm.controls.genericComment.value
+        markingComment: formValue.markingComment,
+        genericComment: formValue.genericComment
       };
-      this.dialogRef.close(this.markingCommentObj);
+      this.dialogRef.close(markingCommentObj);
     }
   }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -233,6 +233,18 @@ button {
   background: var(--pdf-marker-secondary);
 }
 
+
+.mat-dialog-content::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+  background: #F5F5F5;
+}
+
+.mat-dialog-content::-webkit-scrollbar-thumb {
+  border-radius: 10px;
+  background: var(--pdf-marker-primary);
+}
+
 .mat-expansion-panel {
   background: transparent !important;
   padding: 0!important;


### PR DESCRIPTION
- Consistent styling of modals
- All modals are now scrollable
- Comments can be created without a mark
- Exported marking are positioned precisely
- Pressing cancel on the comment modal no longer creates a blank comment
- Consistent styling of chat icon on marking
- Replace `text annotations` with an SVG icon and a `square annotation` over it for more consistent rendering in different viewers
- Better handling of subscriptions on forms
- Cleanup unused code in modals
- Centralized styling of scrollbars to PDFM gray (unless other stylesheet overrides it)