### PR TITLE
NAM-353 Libre Office version detect fixes

### DIFF
--- a/src-electron/ipc/convert.handler.ts
+++ b/src-electron/ipc/convert.handler.ts
@@ -187,6 +187,14 @@ export function libreOfficeVersion(event: IpcMainInvokeEvent, librePath: string)
   );
 }
 
+function extractVersion(vString: string): string{
+  if (isNil(vString)) {
+    return null;
+  } else {
+    return vString.trim().match(/(\d\.\d(\.\d)*)/)[0];
+  }
+}
+
 function libreOfficeVersionUnix(librePath: string): Promise<string> {
   let versionString = '';
   return new Promise<void>((resolve, reject) => {
@@ -197,7 +205,7 @@ function libreOfficeVersionUnix(librePath: string): Promise<string> {
       versionString += data;
     });
   }).then(() => {
-    return versionString.trim().match(/(\d\.\d(\.\d)*)/)[0];
+    return extractVersion(versionString);
   });
 }
 
@@ -213,7 +221,7 @@ function libreOfficeVersionWindowsPowershell(librePath: string): Promise<string>
       versionString += data;
     });
   }).then(() => {
-    return versionString.trim();
+    return extractVersion(versionString);
   });
 }
 
@@ -230,9 +238,6 @@ function libreOfficeVersionWindowsWmic(librePath: string): Promise<string> {
     });
     childProcess.stdin.end();
   }).then(() => {
-    return versionString.split('\n')[1].trim(); // "7.5.0.3"
-  }, (error) => {
-    console.log(error);
-    return Promise.reject('Failed to retrieve version');
+    return extractVersion(versionString.split('\n')[1]); // "7.5.0.3"
   });
 }

--- a/src/app/components/settings/settings.component.html
+++ b/src/app/components/settings/settings.component.html
@@ -43,10 +43,10 @@
       <button type="button" mat-raised-button (click)="setLibreOfficePath()">Browse</button>&nbsp;&nbsp;
       <mat-form-field class="w-75">
         <div class="pdf-marker-file-upload"> &nbsp;&nbsp;
-          <input type="text" matInput formControlName="libreOfficePath" id="pdf-marker-upload-display" readonly placeholder="Libre Office">
+          <input type="text" matInput formControlName="libreOfficePath" id="pdf-marker-upload-display" readonly placeholder="Libre Office" [errorStateMatcher]="libreOfficeErrorMatcher">
         </div>
         <mat-hint *ngIf="!libreOfficeError" class="text-muted"><b>Version:</b> {{libreOfficeVersion}}</mat-hint>
-        <mat-hint *ngIf="libreOfficeError" class="small">
+        <mat-hint *ngIf="libreOfficeError">
           <span class="text-danger ">{{libreOfficeError}}</span>
           <span
             *ngIf="libreOfficeAutoscan"


### PR DESCRIPTION
- Detect platform to use appropriate method to determine Libre Office version
- Windows: Use `powershell` to determine Libre Office executable version
- Windows: Fallback to `wmic` to determined Libre Office executable version
- Use regex to extract only version number