### PR TITLE
NAM-347 More wigets in top bar

### DIFF
--- a/preload.ts
+++ b/preload.ts
@@ -27,11 +27,11 @@ contextBridge.exposeInMainWorld('updateApi', {
 contextBridge.exposeInMainWorld('assignmentApi', {
   createAssignment: (createAssignmentInfo: AssignmentInfo) => ipcRenderer.invoke('assignments:create', createAssignmentInfo),
   updateAssignment: (updateRequest: AssignmentInfo) => ipcRenderer.invoke('assignments:update', updateRequest),
-  saveMarks: (location: string, submissionInfo: SubmissionInfo) => ipcRenderer.invoke('assignments:saveMarks', location, submissionInfo),
+  saveMarks: (workspaceName: string, assignmentName: string, studentId: string, submissionInfo: SubmissionInfo) => ipcRenderer.invoke('assignments:saveMarks', workspaceName, assignmentName, studentId, submissionInfo),
   getAssignmentSettings: (workspaceName: string, assignmentName: string) => ipcRenderer.invoke('assignments:getAssignmentSettings', workspaceName, assignmentName),
   updateAssignmentSettings: (updatedSettings: any, workspaceName: string, assignmentName: string) => ipcRenderer.invoke('assignments:updateAssignmentSettings', updatedSettings, workspaceName, assignmentName),
   finalizeAssignment: (workspaceFolder: any, assignmentName: string, zipFilePath: string) => ipcRenderer.invoke('assignments:finalizeAssignment', workspaceFolder, assignmentName, zipFilePath),
-  getMarks: (location: string) => ipcRenderer.invoke('assignments:getMarks', location),
+  getMarks: (workspaceName: string, assignmentName: string, studentId: string) => ipcRenderer.invoke('assignments:getMarks', workspaceName, assignmentName, studentId),
   exportAssignment: (shareRequest: ExportAssignmentsRequest) => ipcRenderer.invoke('assignments:exportAssignment', shareRequest),
   updateAssignmentRubric: (workspaceName: string, assignmentName: string, rubricName: string, ) => ipcRenderer.invoke('assignments:updateAssignmentRubric', workspaceName, assignmentName, rubricName),
   getPdfFile: (location: string) => ipcRenderer.invoke('assignments:getPdfFile', location),

--- a/src-electron/ipc/import.handler.ts
+++ b/src-electron/ipc/import.handler.ts
@@ -26,7 +26,7 @@ import {deleteFolderRecursive, isFolder, isNullOrUndefinedOrEmpty, stream2buffer
 
 import JSZip, {JSZipObject} from 'jszip';
 import {getAssignmentDirectoryAbsolutePath, getWorkingDirectoryAbsolutePath} from './workspace.handler';
-import {findTreeNode, TreeNode, TreeNodeType} from '@shared/info-objects/workspace';
+import {findTreeNode, TreeNode, TreeNodeType} from '@shared/info-objects/workspaceTreeNode';
 import {
   getAssignmentSettingsFor,
   readGradesCsv,

--- a/src-electron/ipc/workspace.handler.ts
+++ b/src-electron/ipc/workspace.handler.ts
@@ -11,22 +11,22 @@ import {
 } from '@shared/constants/constants';
 import {mkdir, readdir, rename, stat} from 'fs/promises';
 import {
-  FeedbackAttachments,
-  StudentSubmission, SubmissionAttachments, TreeNode,
+  FeedbackAttachmentsTreeNode,
+  StudentSubmissionTreeNode, SubmissionAttachmentsTreeNode, TreeNode,
   TreeNodeType,
-  Workspace,
-  WorkspaceAssignment, WorkspaceFile
-} from '@shared/info-objects/workspace';
+  WorkspaceTreeNode,
+  AssignmentTreeNode, WorkspaceFileTreeNode
+} from '@shared/info-objects/workspaceTreeNode';
 import {isNullOrUndefinedOrEmpty} from '../utils';
 import {STUDENT_DIRECTORY_NO_NAME_REGEX, STUDENT_DIRECTORY_REGEX} from '../constants';
 
-export function getAssignments(): Promise<Workspace[]> {
+export function getAssignments(): Promise<WorkspaceTreeNode[]> {
   return loadWorkspaces();
 }
 
-function loadWorkspaces(): Promise<Workspace[]> {
+function loadWorkspaces(): Promise<WorkspaceTreeNode[]> {
   return getConfig().then((config) => {
-    const defaultWorkspace: Workspace = {
+    const defaultWorkspace: WorkspaceTreeNode = {
       type: TreeNodeType.WORKSPACE,
       name: DEFAULT_WORKSPACE,
       dateModified: null,
@@ -34,7 +34,7 @@ function loadWorkspaces(): Promise<Workspace[]> {
       parent: null
     };
     const workspaceFolders = config.folders || [];
-    const workspaces: Workspace[] = [defaultWorkspace];
+    const workspaces: WorkspaceTreeNode[] = [defaultWorkspace];
 
     if (isNullOrUndefinedOrEmpty(config.defaultPath)) {
       return workspaces;
@@ -64,8 +64,8 @@ function loadWorkspaces(): Promise<Workspace[]> {
 
 
 
-function loadAssignmentContents(directoryFullPath: string, parent: Workspace): Promise<WorkspaceAssignment> {
-  const assignment: WorkspaceAssignment = {
+function loadAssignmentContents(directoryFullPath: string, parent: WorkspaceTreeNode): Promise<AssignmentTreeNode> {
+  const assignment: AssignmentTreeNode = {
     type: TreeNodeType.ASSIGNMENT,
     dateModified: null,
     name: basename(directoryFullPath),
@@ -112,7 +112,7 @@ function loadAssignmentContents(directoryFullPath: string, parent: Workspace): P
             return Promise.reject(`Student directory not in expected format '${file}'`);
           }
 
-          const submission: StudentSubmission = {
+          const submission: StudentSubmissionTreeNode = {
             dateModified: null,
             type: TreeNodeType.SUBMISSION,
             name: file,
@@ -123,7 +123,7 @@ function loadAssignmentContents(directoryFullPath: string, parent: Workspace): P
             parent: assignment
           };
           assignment.children.push(submission);
-          const feedbackNode: FeedbackAttachments = {
+          const feedbackNode: FeedbackAttachmentsTreeNode = {
             name: FEEDBACK_FOLDER,
             type: TreeNodeType.FEEDBACK_DIRECTORY,
             children: [],
@@ -132,7 +132,7 @@ function loadAssignmentContents(directoryFullPath: string, parent: Workspace): P
           };
           submission.children.push(feedbackNode);
 
-          const submissionAttachments: SubmissionAttachments = {
+          const submissionAttachments: SubmissionAttachmentsTreeNode = {
             name: SUBMISSION_FOLDER,
             type: TreeNodeType.SUBMISSIONS_DIRECTORY,
             children: [],
@@ -160,9 +160,9 @@ function loadAssignmentContents(directoryFullPath: string, parent: Workspace): P
   });
 }
 
-function  loadFiles(directory: string, parent: TreeNode): Promise<WorkspaceFile[]> {
+function  loadFiles(directory: string, parent: TreeNode): Promise<WorkspaceFileTreeNode[]> {
   return readdir(directory).then(files => {
-    const workspaceFiles: WorkspaceFile[] = [];
+    const workspaceFiles: WorkspaceFileTreeNode[] = [];
     const promises: Promise<any>[] = map(files, (file) => {
       return stat(directory + sep + file).then(fileStat => {
         if (fileStat.isFile()) {
@@ -180,9 +180,9 @@ function  loadFiles(directory: string, parent: TreeNode): Promise<WorkspaceFile[
   });
 }
 
-function loadWorkspaceContents(directoryFullPath: string): Promise<Workspace> {
+function loadWorkspaceContents(directoryFullPath: string): Promise<WorkspaceTreeNode> {
   // This directory is a workspace
-  const workspace: Workspace = {
+  const workspace: WorkspaceTreeNode = {
     type: TreeNodeType.WORKSPACE,
     dateModified: null,
     name: basename(directoryFullPath),

--- a/src/app/components/assignment-list/assignment-list.component.ts
+++ b/src/app/components/assignment-list/assignment-list.component.ts
@@ -3,13 +3,13 @@ import {AssignmentService} from '../../services/assignment.service';
 import {Subscription} from 'rxjs';
 import {
   findTreeNodes,
-  StudentSubmission,
+  StudentSubmissionTreeNode,
   TreeNode,
   TreeNodeType,
-  Workspace,
-  WorkspaceAssignment,
-  WorkspaceFile
-} from '@shared/info-objects/workspace';
+  WorkspaceTreeNode,
+  AssignmentTreeNode,
+  WorkspaceFileTreeNode
+} from '@shared/info-objects/workspaceTreeNode';
 import {FlatTreeControl} from '@angular/cdk/tree';
 import {isNil, map} from 'lodash';
 import {RoutesEnum} from '../../utils/routes.enum';
@@ -67,7 +67,7 @@ function getIconOpen(treeNode: TreeNode): string {
   }
 }
 
-function buildTreeNodes(workspaces: Workspace[]): DisplayTreeNode[] {
+function buildTreeNodes(workspaces: WorkspaceTreeNode[]): DisplayTreeNode[] {
   const treeNodes: DisplayTreeNode[] = [];
   treeId = 0;
   workspaces.forEach(workspace => {
@@ -110,7 +110,7 @@ export class AssignmentListComponent implements OnInit, OnDestroy {
               private submissionNavigationService: SubmissionNavigationService) { }
 
 
-  workspaces: Workspace[] = [];
+  workspaces: WorkspaceTreeNode[] = [];
   treeControl = new FlatTreeControl<DisplayTreeNode>(node => node.level, node => node.children.length > 0);
 
   treeFlattener = new MatTreeFlattener(
@@ -173,7 +173,7 @@ export class AssignmentListComponent implements OnInit, OnDestroy {
     } else if (node.type === TreeNodeType.WORKSPACE) {
       this.openWorkspaceOverview(node);
     } else if (node.type === TreeNodeType.FILE && (node.parent.type === TreeNodeType.SUBMISSIONS_DIRECTORY || node.parent.type === TreeNodeType.FEEDBACK_DIRECTORY)) {
-      this.openDocument(node as WorkspaceFile);
+      this.openDocument(node as WorkspaceFileTreeNode);
     }
   }
 
@@ -189,7 +189,7 @@ export class AssignmentListComponent implements OnInit, OnDestroy {
     this.router.navigate([RoutesEnum.ASSIGNMENT_WORKSPACE_OVERVIEW, node.name]);
   }
 
-  private openDocument(node: WorkspaceFile): void {
+  private openDocument(node: WorkspaceFileTreeNode): void {
     this.submissionNavigationService.openSubmission(node).subscribe();
   }
 

--- a/src/app/components/assignment-marking/assignment-marking-page/assignment-marking-page.component.ts
+++ b/src/app/components/assignment-marking/assignment-marking-page/assignment-marking-page.component.ts
@@ -32,6 +32,7 @@ import {
 } from '../../confirmation-dialog/confirmation-dialog.component';
 import {MatDialogConfig} from '@angular/material/dialog';
 import {RenderTask} from 'pdfjs-dist/types/src/display/api';
+import {DEFAULT_MARKS} from '@shared/constants/constants';
 
 const eventBus = new EventBus();
 
@@ -208,11 +209,11 @@ export class AssignmentMarkingPageComponent implements OnInit, AfterViewInit, On
     };
 
     if (mark.iconType === IconTypeEnum.FULL_MARK) {
-      mark.totalMark = this.assignmentMarkingComponent.defaultFullMark;
+      mark.totalMark = DEFAULT_MARKS.FULL;
     } else if (mark.iconType === IconTypeEnum.HALF_MARK) {
-      mark.totalMark = (this.assignmentMarkingComponent.defaultFullMark / 2);
+      mark.totalMark = (DEFAULT_MARKS.FULL / 2);
     } else if (mark.iconType === IconTypeEnum.CROSS) {
-      mark.totalMark = this.assignmentMarkingComponent.defaultIncorrectMark;
+      mark.totalMark = DEFAULT_MARKS.INCORRECT;
     } else if (mark.iconType === IconTypeEnum.NUMBER) {
       const config = this.assignmentMarkingComponent.openNewMarkingCommentModal();
       const handelCommentFN = (formData: any) => {

--- a/src/app/components/assignment-marking/assignment-marking-toolbar/assignment-marking-toolbar.component.html
+++ b/src/app/components/assignment-marking/assignment-marking-toolbar/assignment-marking-toolbar.component.html
@@ -51,14 +51,6 @@
     </span>
     </div>
   </ng-container>
-  <button
-    color="primary"
-    matTooltip="Preview Marks"
-    mat-button
-    mat-icon-button
-    (click)="onControl($event, 'previewMarks')">
-    <mat-icon>announcement</mat-icon>
-  </button>
   </div>
 
 

--- a/src/app/components/assignment-marking/assignment-marking.component.ts
+++ b/src/app/components/assignment-marking/assignment-marking.component.ts
@@ -14,7 +14,7 @@ import {filter, from, mergeMap, Observable, Subscription, tap, throwError} from 
 import {ActivatedRoute, NavigationStart, Router} from '@angular/router';
 import {AppService} from '../../services/app.service';
 import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
-import {AssignmentSettingsInfo, AssignmentState, SubmissionState} from '@shared/info-objects/assignment-settings.info';
+import {AssignmentSettingsInfo} from '@shared/info-objects/assignment-settings.info';
 import {getDocument, GlobalWorkerOptions, PDFDocumentProxy} from 'pdfjs-dist';
 import {cloneDeep, find, isNil, times} from 'lodash';
 import {MarkInfo} from '@shared/info-objects/mark.info';
@@ -36,7 +36,6 @@ import {
 import {RoutesEnum} from '../../utils/routes.enum';
 import {SettingsService} from '../../services/settings.service';
 import {SettingInfo} from '@shared/info-objects/setting.info';
-import {PreviewMarksComponent} from './preview-marks/preview-marks.component';
 import {calculateCanEditMarking} from '../../utils/utils';
 
 
@@ -80,8 +79,7 @@ export class AssignmentMarkingComponent implements OnInit, OnDestroy {
   private zoomChangeSubscription: Subscription;
   private routeSubscription: Subscription;
   submissionInfo: SubmissionInfo;
-  readonly defaultFullMark = 1;
-  readonly defaultIncorrectMark = 0;
+
   rubric: IRubric;
   showRubric = false;
   showPdf = true;
@@ -289,8 +287,6 @@ export class AssignmentMarkingComponent implements OnInit, OnDestroy {
         break;
       case 'clearAll' :   this.clearMarks();
         break;
-      case 'previewMarks' :   this.previewMarks();
-        break;
       case 'prevPage' :   this.onPagedChanged(this.currentPage - 1);
         break;
       case 'nextPage' :   this.onPagedChanged(this.currentPage + 1);
@@ -440,21 +436,6 @@ export class AssignmentMarkingComponent implements OnInit, OnDestroy {
     this.appService.createDialog(ConfirmationDialogComponent, config, shouldDeleteFn);
   }
 
-
-  private previewMarks() {
-    const config: MatDialogConfig = new MatDialogConfig();
-    config.width = '400px';
-    config.height = '500px';
-    config.disableClose = true;
-
-    config.data = {
-      assignmentPath: this.pdf,
-      submissionInfo: this.submissionInfo,
-      defaultTick: this.defaultFullMark,
-      incorrectTick: this.defaultIncorrectMark
-    };
-    this.appService.createDialog(PreviewMarksComponent, config);
-  }
 
   openNewMarkingCommentModal(): MatDialogConfig {
     const config = new MatDialogConfig();

--- a/src/app/components/assignment-marking/assignment-marking.component.ts
+++ b/src/app/components/assignment-marking/assignment-marking.component.ts
@@ -253,7 +253,10 @@ export class AssignmentMarkingComponent implements OnInit, OnDestroy {
   }
 
   private loadMarks(): Observable<SubmissionInfo> {
-    return this.assignmentService.getSavedMarks(PdfmUtilsService.dirname(this.pdf, 2))
+    // TODO ideally SubmissionInfo should contain the studentId...
+    const studentDirectoryName = PdfmUtilsService.basename(PdfmUtilsService.dirname(this.pdf, 2));
+    const submission = find(this.assignmentSettings.submissions, s => s.directoryName === studentDirectoryName);
+    return this.assignmentService.getSavedMarks(this.workspaceName, this.assignmentName, submission.studentId)
       .pipe(
         tap((marks) => {
           this.submissionInfo = this.setupMark(marks);
@@ -336,7 +339,11 @@ export class AssignmentMarkingComponent implements OnInit, OnDestroy {
     } as SubmissionInfo;
     markDetails.pageSettings[pageIndex] = pageSettings;
     this.busyService.start();
-    return this.assignmentService.saveMarks(this.workspaceName, PdfmUtilsService.dirname(this.pdf, 2), markDetails)
+
+    // TODO ideally SubmissionInfo should contain the studentId...
+    const studentDirectoryName = PdfmUtilsService.basename(PdfmUtilsService.dirname(this.pdf, 2));
+    const submission = find(this.assignmentSettings.submissions, s => s.directoryName === studentDirectoryName);
+    return this.assignmentService.saveMarks(this.workspaceName, this.assignmentName, submission.studentId, markDetails)
       .pipe(
         map(() => {
           this.busyService.stop();
@@ -376,7 +383,10 @@ export class AssignmentMarkingComponent implements OnInit, OnDestroy {
       marks: marks || this.submissionInfo.marks
     } as MarkingSubmissionInfo;
     this.busyService.start();
-    return this.assignmentService.saveMarks(this.workspaceName, PdfmUtilsService.dirname(this.pdf, 2), markDetails)
+    // TODO ideally SubmissionInfo should contain the studentId...
+    const studentDirectoryName = PdfmUtilsService.basename(PdfmUtilsService.dirname(this.pdf, 2));
+    const submission = find(this.assignmentSettings.submissions, s => s.directoryName === studentDirectoryName);
+    return this.assignmentService.saveMarks(this.workspaceName, this.assignmentName, submission.studentId, markDetails)
       .pipe(
         map(() => {
           this.busyService.stop();

--- a/src/app/components/assignment-marking/mark-type-icon/mark-type-icon.component.ts
+++ b/src/app/components/assignment-marking/mark-type-icon/mark-type-icon.component.ts
@@ -172,7 +172,7 @@ export class MarkTypeIconComponent implements OnInit, OnDestroy {
   }
 
   onTotalMarkChange() {
-    const number = parseInt(this.iconForm.controls.totalMark.value, 10);
+    const number = parseFloat(this.iconForm.controls.totalMark.value);
     if (!isNaN(number)) {
       const updatedMark: MarkInfo = cloneDeep(this.mark);
       updatedMark.totalMark = number;

--- a/src/app/components/assignment-overview/allocate-markers-modal/allocate-markers-modal.component.ts
+++ b/src/app/components/assignment-overview/allocate-markers-modal/allocate-markers-modal.component.ts
@@ -5,7 +5,7 @@ import {SettingsService} from '../../../services/settings.service';
 import {GroupMember, Marker, SettingInfo} from '@shared/info-objects/setting.info';
 import {Subscription} from 'rxjs';
 import {cloneDeep, filter, find, isNil, shuffle, sortBy, without} from 'lodash';
-import {StudentSubmission, TreeNodeType, WorkspaceAssignment} from '@shared/info-objects/workspace';
+import {StudentSubmissionTreeNode, TreeNodeType, AssignmentTreeNode} from '@shared/info-objects/workspaceTreeNode';
 import {
   AssignmentSettingsInfo,
   Submission,
@@ -105,8 +105,8 @@ export class AllocateMarkersModalComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.assignmentName = this.data.assignmentName;
     const assignmentSettings: AssignmentSettingsInfo = this.data.assignmentSettings;
-    const workspaceAssignment: WorkspaceAssignment = this.data.workspaceAssignment;
-    const studentDirectories: StudentSubmission[] = workspaceAssignment.children.filter(i => i.type === TreeNodeType.SUBMISSION) as StudentSubmission[];
+    const workspaceAssignment: AssignmentTreeNode = this.data.workspaceAssignment;
+    const studentDirectories: StudentSubmissionTreeNode[] = workspaceAssignment.children.filter(i => i.type === TreeNodeType.SUBMISSION) as StudentSubmissionTreeNode[];
     this.studentCount = studentDirectories.length;
     this.submissions = studentDirectories.filter(submissionDirectory => {
       return !isNil(submissionDirectory.children.find(f => f.type === TreeNodeType.SUBMISSIONS_DIRECTORY).children[0]);

--- a/src/app/components/assignment-overview/assignment-overview.component.ts
+++ b/src/app/components/assignment-overview/assignment-overview.component.ts
@@ -35,11 +35,11 @@ import {BusyService} from '../../services/busy.service';
 import {MatSort, MatSortable} from '@angular/material/sort';
 import {cloneDeep, every, filter, find, forEach, isEmpty, isNil, map, some, sortBy, uniq} from 'lodash';
 import {
-  StudentSubmission,
+  StudentSubmissionTreeNode,
   TreeNodeType,
-  WorkspaceAssignment,
-  WorkspaceFile
-} from '@shared/info-objects/workspace';
+  AssignmentTreeNode,
+  WorkspaceFileTreeNode
+} from '@shared/info-objects/workspaceTreeNode';
 import {DEFAULT_WORKSPACE, MARK_FILE} from '@shared/constants/constants';
 import {AllocateMarkersModalComponent} from './allocate-markers-modal/allocate-markers-modal.component';
 import {DateTime} from 'luxon';
@@ -79,7 +79,7 @@ export interface AssignmentDetails {
 
   submissionDirectoryName?: string;
 
-  pdfFile: WorkspaceFile;
+  pdfFile: WorkspaceFileTreeNode;
 
   marker?: string;
   canReAllocate?: boolean;
@@ -112,7 +112,7 @@ export class AssignmentOverviewComponent implements OnInit, OnDestroy, AfterView
   private sortSubscription: Subscription;
   private settings: SettingInfo;
   assignmentSettings: AssignmentSettingsInfo;
-  private workspaceAssignment: WorkspaceAssignment;
+  private workspaceAssignment: AssignmentTreeNode;
   isSettings: boolean;
   rubrics: IRubricName[] = [];
 
@@ -212,7 +212,7 @@ export class AssignmentOverviewComponent implements OnInit, OnDestroy, AfterView
       );
   }
 
-  private getAssignmentHierarchy(): Observable<WorkspaceAssignment> {
+  private getAssignmentHierarchy(): Observable<AssignmentTreeNode> {
     return this.assignmentService.getAssignmentHierarchy(this.workspaceName, this.assignmentName)
       .pipe(
         tap((workspaceAssignment) => {
@@ -234,7 +234,7 @@ export class AssignmentOverviewComponent implements OnInit, OnDestroy, AfterView
       let index = 0;
       const selfEmail = this.settings.user ? this.settings.user.email : null;
       const selfId = this.settings.user ? this.settings.user.id : null;
-      filter(this.workspaceAssignment.children, {type: TreeNodeType.SUBMISSION}).forEach((workspaceSubmission: StudentSubmission) => {
+      filter(this.workspaceAssignment.children, {type: TreeNodeType.SUBMISSION}).forEach((workspaceSubmission: StudentSubmissionTreeNode) => {
 
         const submission: Submission = find(this.assignmentSettings.submissions, {directoryName: workspaceSubmission.name});
         const fullName = workspaceSubmission.studentSurname + (isNil(workspaceSubmission.studentName) ? '' : ', ' + workspaceSubmission.studentName);
@@ -274,9 +274,9 @@ export class AssignmentOverviewComponent implements OnInit, OnDestroy, AfterView
           value.time = DateTime.fromJSDate(marksFile.dateModified).toFormat('HH:mm:ss');
         }
         if (submissionDirectory && submissionDirectory.children.length > 0) {
-          value.pdfFile = submissionDirectory.children[0] as WorkspaceFile;
+          value.pdfFile = submissionDirectory.children[0] as WorkspaceFileTreeNode;
         } else if (feedbackDirectory && feedbackDirectory.children.length > 0) {
-          value.pdfFile = feedbackDirectory.children[0] as WorkspaceFile;
+          value.pdfFile = feedbackDirectory.children[0] as WorkspaceFileTreeNode;
         }
         if (!isNil(value.pdfFile)) {
           value.assignment = value.pdfFile.name;

--- a/src/app/components/assignment-workspace-overview/assignment-workspace-overview.component.ts
+++ b/src/app/components/assignment-workspace-overview/assignment-workspace-overview.component.ts
@@ -12,7 +12,7 @@ import {
 import {Observable, Subscription, tap, throwError} from 'rxjs';
 import {catchError} from 'rxjs/operators';
 import {BusyService} from '../../services/busy.service';
-import {TreeNodeType, Workspace} from '@shared/info-objects/workspace';
+import {TreeNodeType, WorkspaceTreeNode} from '@shared/info-objects/workspaceTreeNode';
 import {PdfmUtilsService} from '../../services/pdfm-utils.service';
 import {RoutesEnum} from '../../utils/routes.enum';
 import {isNil, reduce} from 'lodash';
@@ -44,7 +44,7 @@ export class AssignmentWorkspaceOverviewComponent implements OnInit, OnDestroy, 
   workspaceRows: WorkspaceDetails[] = [];
   workspaceName = 'Workspace Name';
   assignmentsLength;
-  private workspace: Workspace;
+  private workspace: WorkspaceTreeNode;
   private sortSubscription: Subscription;
   subscription: Subscription;
 

--- a/src/app/components/create-assignment/create-assignment.component.ts
+++ b/src/app/components/create-assignment/create-assignment.component.ts
@@ -18,7 +18,7 @@ import {find, findIndex, isEmpty, isEqual, isNil, times} from 'lodash';
 import {forkJoin, mergeMap, Observable, of, tap, throwError} from 'rxjs';
 import {BusyService} from '../../services/busy.service';
 import {catchError, map} from 'rxjs/operators';
-import {StudentSubmission, TreeNodeType} from '@shared/info-objects/workspace';
+import {StudentSubmissionTreeNode, TreeNodeType} from '@shared/info-objects/workspaceTreeNode';
 import {DEFAULT_WORKSPACE, SUPPORTED_SUBMISSION_TYPES} from '@shared/constants/constants';
 import {AppSelectedPathInfo} from '@shared/info-objects/app-selected-path.info';
 
@@ -127,7 +127,7 @@ export class CreateAssignmentComponent implements OnInit, OnDestroy {
                 tap((workspaceAssignment) => {
                   if (!isNil(workspaceAssignment)) {
                     workspaceAssignment.children.filter((c => c.type === TreeNodeType.SUBMISSION))
-                      .forEach((studentSubmission: StudentSubmission) => {
+                      .forEach((studentSubmission: StudentSubmissionTreeNode) => {
                         const studentSubmissionModel: StudentSubmissionModel = {
                           studentName: studentSubmission.studentName,
                           studentSurname: studentSubmission.studentSurname,

--- a/src/app/components/file-explorer-modal/file-explorer-modal.component.ts
+++ b/src/app/components/file-explorer-modal/file-explorer-modal.component.ts
@@ -2,7 +2,7 @@ import {Component, Inject, OnInit} from '@angular/core';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {FlatTreeControl} from '@angular/cdk/tree';
 import {MatTreeFlatDataSource, MatTreeFlattener} from '@angular/material/tree';
-import {TreeNode} from '@shared/info-objects/workspace';
+import {TreeNode} from '@shared/info-objects/workspaceTreeNode';
 import {DisplayTreeNode} from '../assignment-list/assignment-list.component';
 import {PDFM_FILE_SORT} from '@shared/constants/constants';
 

--- a/src/app/components/submission-navigator/submission-navigator.component.html
+++ b/src/app/components/submission-navigator/submission-navigator.component.html
@@ -1,10 +1,10 @@
-<div class="submission-navigator-wrapper" [style.display]="activeSubmission == null ? 'none' : 'flex'">
+<div class="submission-navigator-wrapper" [style.display]="selectedSubmission == null ? 'none' : 'flex'">
 
 
   <div class="submission-navigator-assignment-name-wrapper">
     <button mat-button (click)="openAssignment()">
       <mat-icon style="font-size: 36px; width: 36px; height: 36px">description</mat-icon>
-      <span style="font-size: 1.3rem;font-weight: normal;margin-left: 5px;">{{activeSubmission?.assignment.name}}</span>
+      <span style="font-size: 1.3rem;font-weight: normal;margin-left: 5px;">{{selectedSubmission?.assignment.name}}</span>
     </button>
   </div>
 
@@ -15,7 +15,7 @@
 
 
   <div class="submission-navigator-submission-wrapper">
-    <div class="mark-wrapper">
+    <div class="mark-wrapper" (click)="previewMarks()" role="button" matTooltip="Preview Marks">
       <span>{{marks}}</span>
     </div>
 

--- a/src/app/components/submission-navigator/submission-navigator.component.html
+++ b/src/app/components/submission-navigator/submission-navigator.component.html
@@ -1,5 +1,6 @@
 <div class="submission-navigator-wrapper" [style.display]="activeSubmission == null ? 'none' : 'flex'">
 
+
   <div class="submission-navigator-assignment-name-wrapper">
     <button mat-button (click)="openAssignment()">
       <mat-icon style="font-size: 36px; width: 36px; height: 36px">description</mat-icon>
@@ -7,7 +8,17 @@
     </button>
   </div>
 
+  <div class="marking-detail-wrapper me-3">
+    <div class="marker-name">{{marker}}</div>
+    <small class="marker-label">Marker</small>
+  </div>
+
+
   <div class="submission-navigator-submission-wrapper">
+    <div class="mark-wrapper">
+      <span>{{marks}}</span>
+    </div>
+
     <button mat-icon-button matTooltip="Previous" [disabled]="busy || !canPrevious" (click)="previous()">
       <mat-icon>arrow_back</mat-icon>
     </button>

--- a/src/app/components/submission-navigator/submission-navigator.component.scss
+++ b/src/app/components/submission-navigator/submission-navigator.component.scss
@@ -3,6 +3,32 @@
   padding-left: 8px;
 }
 
+.marking-detail-wrapper{
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  font-size: 14px;
+
+  .marker-name, .marker-label{
+    line-height: inherit;
+    height: 1rem;
+    font-weight: 500;
+  }
+}
+
+.mark-wrapper{
+  border-radius: 1.6rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 2px solid var(--pdf-marker-primary);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: nowrap;
+  background: #ffffff;
+  color: var(--pdf-marker-primary);
+}
+
 .submission-navigator-assignment-name-wrapper{
   display: flex;
   flex-grow: 1;
@@ -32,3 +58,4 @@ button.mat-menu-item{
     color: #555555;
   }
 }
+

--- a/src/app/components/submission-navigator/submission-navigator.component.scss
+++ b/src/app/components/submission-navigator/submission-navigator.component.scss
@@ -18,7 +18,7 @@
 
 .mark-wrapper{
   border-radius: 1.6rem;
-  width: 2.5rem;
+  min-width: 2.5rem;
   height: 2.5rem;
   border: 2px solid var(--pdf-marker-primary);
   display: flex;
@@ -27,6 +27,7 @@
   flex-wrap: nowrap;
   background: #ffffff;
   color: var(--pdf-marker-primary);
+  font-size: 1rem;
 }
 
 .submission-navigator-assignment-name-wrapper{

--- a/src/app/components/submission-navigator/submission-navigator.component.ts
+++ b/src/app/components/submission-navigator/submission-navigator.component.ts
@@ -4,14 +4,22 @@ import {StudentSubmissionTreeNode, TreeNodeType, WorkspaceFileTreeNode} from '@s
 import {RoutesEnum} from '../../utils/routes.enum';
 import {AssignmentService} from '../../services/assignment.service';
 import {Router} from '@angular/router';
-import {mergeMap, Observable, Subscription, tap} from 'rxjs';
+import {mergeMap, Observable, of, Subscription, tap} from 'rxjs';
 import {SelectedSubmission} from '../../info-objects/selected-submission';
 import {SettingsService} from '../../services/settings.service';
 import {SubmissionNavigationService} from '../../services/submission-navigation.service';
-import {AssignmentSettingsInfo, DistributionFormat, Submission} from '@shared/info-objects/assignment-settings.info';
+import {
+  AssignmentSettingsInfo,
+  DistributionFormat,
+  Submission,
+  SubmissionState
+} from '@shared/info-objects/assignment-settings.info';
 import {SettingInfo} from '@shared/info-objects/setting.info';
-import {SubmissionInfo, SubmissionType} from '@shared/info-objects/submission.info';
+import {SubmissionInfo} from '@shared/info-objects/submission.info';
 import {MarkInfo} from '@shared/info-objects/mark.info';
+import {MatDialogConfig} from '@angular/material/dialog';
+import {PreviewMarksComponent} from '../assignment-marking/preview-marks/preview-marks.component';
+import {AppService} from '../../services/app.service';
 
 export interface SubmissionItem {
   studentFullName: string;
@@ -50,8 +58,12 @@ export class SubmissionNavigatorComponent implements OnInit, OnDestroy {
   /**
    * Active selected submission
    */
-  activeSubmission: SelectedSubmission;
+  selectedSubmission: SelectedSubmission;
+  private activeSubmissionInfo: SubmissionInfo;
+  private assignmentSubmission: Submission;
 
+  private workspaceName: string;
+  private assignmentName: string;
   /**
    * Items to display in the droplist
    */
@@ -75,36 +87,62 @@ export class SubmissionNavigatorComponent implements OnInit, OnDestroy {
 
   constructor(private assignmentService: AssignmentService,
               private settingsService: SettingsService,
+              private appService: AppService,
               private router: Router,
               private submissionNavigationService: SubmissionNavigationService) { }
 
   ngOnInit(): void {
     this.submissionChangeSubscription = this.assignmentService.submissionUpdated.subscribe((submissionUpdateEvent) => {
-      if (submissionUpdateEvent.workspaceName === this.activeSubmission.workspace.name &&
-        submissionUpdateEvent.assignmentName === this.activeSubmission.assignment.name &&
-        submissionUpdateEvent.studentId === this.menuItems[this.activeIndex].studentId) {
-         this.recalculateMark(submissionUpdateEvent.submission);
+      if (isNil(this.selectedSubmission)) {
+        return; // This only happens in dev mode when the page reloads
       }
-      console.log(submissionUpdateEvent);
+      if (submissionUpdateEvent.workspaceName === this.workspaceName &&
+        submissionUpdateEvent.assignmentName === this.assignmentName &&
+        submissionUpdateEvent.studentId === this.assignmentSubmission.studentId) {
+        this.activeSubmissionInfo = submissionUpdateEvent.submission;
+        this.recalculateMark();
+      }
     });
 
     this.settingsService.getConfigurations().subscribe((settings) => {
       this.settings = settings;
 
-      this.assignmentSubscription = this.assignmentService.selectedSubmissionChanged.subscribe((submission) => {
-        this.activeSubmission = submission;
-        this.generateDataFromModel(submission);
-        this.loadMarkingDetails();
+      this.assignmentSubscription = this.assignmentService.selectedSubmissionChanged.pipe(
+        mergeMap(selectedSubmission => {
+          this.selectedSubmission = selectedSubmission;
+          if (isNil(selectedSubmission)) {
+            this.workspaceName = null;
+            this.assignmentName = null;
+            this.menuItems = [];
+            this.marker = null;
+            return of(null);
+          } else {
+            this.workspaceName = selectedSubmission.workspace.name;
+            this.assignmentName = selectedSubmission.assignment.name;
+            return this.loadAssignmentSettings().pipe(
+              tap(() => {
+                const studentDirectory = selectedSubmission.pdfFile.parent.parent.name;
+                this.assignmentSubmission = find(this.assignmentSettings.submissions, {directoryName: studentDirectory});
+              }),
+              tap(() => this.generateDataFromModel()),
+              mergeMap(() => this.getMarks()),
+              tap(() => this.recalculateMark()),
+              tap(() => this.loadMarker())
+            );
+          }
+        })
+      ).subscribe(() => {
+
       });
     });
 
 
   }
 
-  private recalculateMark(submissionInfo: SubmissionInfo) {
+  private recalculateMark() {
     if (isNil(this.assignmentSettings.rubric)) {
       let sum = 0;
-      forEach(submissionInfo.marks as MarkInfo[][], (pageMarks) => {
+      forEach(this.activeSubmissionInfo.marks as MarkInfo[][], (pageMarks) => {
         forEach(pageMarks, (mark) => {
           sum += mark.totalMark;
         });
@@ -112,9 +150,9 @@ export class SubmissionNavigatorComponent implements OnInit, OnDestroy {
       this.marks = sum;
     } else {
       let sum = 0;
-      forEach(submissionInfo.marks as number[], (rubricIndex, index) => {
+      forEach(this.activeSubmissionInfo.marks as number[], (rubricIndex, index) => {
         if (!isNil(rubricIndex)) {
-         sum +=  this.assignmentSettings.rubric.criterias[index].levels[rubricIndex].score;
+          sum +=  this.assignmentSettings.rubric.criterias[index].levels[rubricIndex].score;
         }
       });
       this.marks = sum;
@@ -123,26 +161,13 @@ export class SubmissionNavigatorComponent implements OnInit, OnDestroy {
 
   private getMarks(): Observable<SubmissionInfo> {
     return this.assignmentService.getSavedMarks(
-      this.activeSubmission.workspace.name,
-      this.activeSubmission.assignment.name,
-      this.menuItems[this.activeIndex].studentId)
+      this.workspaceName,
+      this.assignmentName,
+      this.assignmentSubmission.studentId
+    )
       .pipe(
-        tap((submissionInfo) => this.recalculateMark(submissionInfo))
+        tap((submissionInfo) => this.activeSubmissionInfo = submissionInfo)
       );
-  }
-
-  private loadMarkingDetails() {
-    if (isNil(this.activeSubmission)) {
-      this.marker = null;
-    } else {
-      this.loadAssignmentSettings(this.activeSubmission)
-        .pipe(
-          mergeMap(() => this.getMarks())
-        )
-        .subscribe(() => {
-          this.loadMarker();
-        });
-    }
   }
 
   private loadMarker() {
@@ -151,18 +176,18 @@ export class SubmissionNavigatorComponent implements OnInit, OnDestroy {
       this.marker = 'Me';
     } else {
       const myEmail = this.settings.user.email;
-      const assignmentSubmission: Submission = find(this.assignmentSettings.submissions, {studentId: this.menuItems[this.activeIndex].studentId});
-      if (isNil(assignmentSubmission.allocation) || assignmentSubmission.allocation.email === myEmail) {
+
+      if (isNil(this.assignmentSubmission.allocation) || this.assignmentSubmission.allocation.email === myEmail) {
         this.marker = 'Me';
       } else {
-        const marker = find(this.settings.markers, {email: assignmentSubmission.allocation.email});
+        const marker = find(this.settings.markers, {email: this.assignmentSubmission.allocation.email});
         this.marker = marker.name;
       }
     }
   }
 
-  private loadAssignmentSettings(selectedSubmission: SelectedSubmission): Observable <AssignmentSettingsInfo> {
-    return this.assignmentService.getAssignmentSettings(selectedSubmission.workspace.name, selectedSubmission.assignment.name)
+  private loadAssignmentSettings(): Observable <AssignmentSettingsInfo> {
+    return this.assignmentService.getAssignmentSettings(this.workspaceName, this.assignmentName)
       .pipe(
         tap((assignmentSettingsInfo) => this.assignmentSettings = assignmentSettingsInfo)
       );
@@ -179,37 +204,44 @@ export class SubmissionNavigatorComponent implements OnInit, OnDestroy {
 
   }
 
-  private generateDataFromModel(activeSubmission: SelectedSubmission) {
-    if (isNil(activeSubmission)) {
-      this.menuItems = [];
-    } else {
-      this.menuItems = filter(activeSubmission.assignment.children, {type: TreeNodeType.SUBMISSION})
-        .map((studentSubmission: StudentSubmissionTreeNode) => {
+  private generateDataFromModel() {
+    this.menuItems = this.assignmentSettings.submissions.map((submission: Submission) => {
 
-          // Find submission or feedback pdf
-          let submissionFile: WorkspaceFileTreeNode = studentSubmission.children
-            .find((tn) => tn.type === TreeNodeType.SUBMISSIONS_DIRECTORY).children[0] as WorkspaceFileTreeNode;
-          if (isNil(submissionFile)) {
-            submissionFile = studentSubmission.children.find((tn) => tn.type === TreeNodeType.FEEDBACK_DIRECTORY).children[0] as WorkspaceFileTreeNode;
-          }
+      if (submission.state === SubmissionState.NO_SUBMISSION) {
+        return null; // This student does not have submissions or feedback...
+      }
+      const submissionTreeNode: StudentSubmissionTreeNode = find(this.selectedSubmission.assignment.children, {
+        type: TreeNodeType.SUBMISSION,
+        name: submission.directoryName
+      }) as StudentSubmissionTreeNode;
 
-          if (isNil(submissionFile)) {
-            return null; // This student does not have submissions or feedback...
-          }
+      // Find submission or feedback pdf
+      let submissionFile: WorkspaceFileTreeNode = find(submissionTreeNode.children, {
+        type :  TreeNodeType.SUBMISSIONS_DIRECTORY
+      }).children[0] as WorkspaceFileTreeNode;
 
-          return {
-            studentFullName: studentSubmission.studentSurname + (isNil(studentSubmission.studentName) ? '' : ', ' + studentSubmission.studentName),
-            studentId: studentSubmission.studentId,
-            pdfFile: submissionFile
-          };
-        })
-        .filter((mi) => !isNil(mi))
-        .sort((a, b) => a.studentFullName.localeCompare(b.studentFullName));
-      this.activeIndex = findIndex(this.menuItems, (item) => {
-        return item.pdfFile === activeSubmission.pdfFile;
-      });
-      this.updateStates();
-    }
+      if (isNil(submissionFile)) {
+        submissionFile = find(submissionTreeNode.children, {
+          type: TreeNodeType.FEEDBACK_DIRECTORY
+        }).children[0] as WorkspaceFileTreeNode;
+      }
+
+      if (isNil(submissionFile)) {
+        return null;
+      }
+
+      return {
+        studentFullName: submission.studentSurname + (isNil(submission.studentName) ? '' : ', ' + submission.studentName),
+        studentId: submission.studentId,
+        pdfFile: submissionFile
+      };
+    })
+      .filter((mi) => !isNil(mi))
+      .sort((a, b) => a.studentFullName.localeCompare(b.studentFullName));
+    this.activeIndex = findIndex(this.menuItems, (item) => {
+      return item.pdfFile === this.selectedSubmission.pdfFile;
+    });
+    this.updateStates();
   }
 
   next(): void {
@@ -235,12 +267,25 @@ export class SubmissionNavigatorComponent implements OnInit, OnDestroy {
   }
 
   openAssignment() {
-    this.router.navigate([RoutesEnum.ASSIGNMENT_OVERVIEW, this.activeSubmission.assignment.name, this.activeSubmission.workspace.name]);
+    this.router.navigate([RoutesEnum.ASSIGNMENT_OVERVIEW, this.selectedSubmission.assignment.name, this.selectedSubmission.workspace.name]);
   }
 
   private updateStates(): void {
     this.canNext = this.activeIndex < this.menuItems.length - 1;
     this.canPrevious = this.activeIndex > 0;
+  }
+
+  private previewMarks() {
+    const config: MatDialogConfig = new MatDialogConfig();
+    config.width = '400px';
+    config.height = '500px';
+    config.disableClose = true;
+    config.data = {
+      studentSubmission: this.assignmentSubmission,
+      submissionInfo: this.activeSubmissionInfo,
+      assignmentSettings: this.assignmentSettings
+    };
+    this.appService.createDialog(PreviewMarksComponent, config);
   }
 
 }

--- a/src/app/info-objects/selected-submission.ts
+++ b/src/app/info-objects/selected-submission.ts
@@ -1,7 +1,7 @@
-import {Workspace, WorkspaceAssignment, WorkspaceFile} from '@shared/info-objects/workspace';
+import {WorkspaceTreeNode, AssignmentTreeNode, WorkspaceFileTreeNode} from '@shared/info-objects/workspaceTreeNode';
 
 export interface SelectedSubmission {
-  workspace: Workspace;
-  assignment: WorkspaceAssignment;
-  pdfFile: WorkspaceFile;
+  workspace: WorkspaceTreeNode;
+  assignment: AssignmentTreeNode;
+  pdfFile: WorkspaceFileTreeNode;
 }

--- a/src/app/services/convert.service.ts
+++ b/src/app/services/convert.service.ts
@@ -2,7 +2,7 @@ import {Injectable} from '@angular/core';
 import {ConvertIpcService} from '@shared/ipc/convert.ipc-service';
 import {first, map, mergeMap, Observable, tap} from 'rxjs';
 import {fromIpcResponse} from './ipc.utils';
-import {findTreeNode, WorkspaceFile} from '@shared/info-objects/workspace';
+import {findTreeNode, WorkspaceFileTreeNode} from '@shared/info-objects/workspaceTreeNode';
 import {PdfmUtilsService} from './pdfm-utils.service';
 import {WorkspaceService} from './workspace.service';
 
@@ -27,7 +27,7 @@ export class ConvertService {
         if (!oldSubmissionFile.startsWith(workspace)) {
           oldSubmissionFile = workspace + '/' + oldSubmissionFile;
         }
-        const submissionFile: WorkspaceFile = findTreeNode(oldSubmissionFile, workspaces) as WorkspaceFile;
+        const submissionFile: WorkspaceFileTreeNode = findTreeNode(oldSubmissionFile, workspaces) as WorkspaceFileTreeNode;
         submissionFile.name = PdfmUtilsService.basename(newSubmissionFile);
       })
     );

--- a/src/app/services/import.service.ts
+++ b/src/app/services/import.service.ts
@@ -3,7 +3,7 @@ import {ImportInfo} from '@shared/info-objects/import.info';
 import {fromIpcResponse} from './ipc.utils';
 import {ImportIpcService} from '@shared/ipc/import.ipc-service';
 import {map, mergeMap, Observable} from 'rxjs';
-import {TreeNode} from '@shared/info-objects/workspace';
+import {TreeNode} from '@shared/info-objects/workspaceTreeNode';
 import {AssignmentValidateResultInfo} from '@shared/info-objects/assignment-validate-result.info';
 import {LectureImportInfo} from '@shared/info-objects/lecture-import.info';
 import {AssignmentSettingsInfo} from '@shared/info-objects/assignment-settings.info';

--- a/src/app/services/pdfm-utils.service.ts
+++ b/src/app/services/pdfm-utils.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {isNil} from 'lodash';
 import {DEFAULT_WORKSPACE} from '@shared/constants/constants';
-import {TreeNode, TreeNodeType} from '@shared/info-objects/workspace';
+import {TreeNode, TreeNodeType} from '@shared/info-objects/workspaceTreeNode';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/services/submission-navigation.service.ts
+++ b/src/app/services/submission-navigation.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import {Workspace, WorkspaceAssignment, WorkspaceFile} from '@shared/info-objects/workspace';
+import {WorkspaceTreeNode, AssignmentTreeNode, WorkspaceFileTreeNode} from '@shared/info-objects/workspaceTreeNode';
 import {map, mergeMap, Observable, of, tap, throwError} from 'rxjs';
 import {PdfmUtilsService} from './pdfm-utils.service';
 import {AssignmentService} from './assignment.service';
@@ -27,9 +27,9 @@ export class SubmissionNavigationService {
               private router: Router) { }
 
 
-  private convertFile(submissionFile: WorkspaceFile): Observable<WorkspaceFile> {
-    const assignment = submissionFile.parent.parent.parent as WorkspaceAssignment;
-    const workspace = assignment.parent as Workspace;
+  private convertFile(submissionFile: WorkspaceFileTreeNode): Observable<WorkspaceFileTreeNode> {
+    const assignment = submissionFile.parent.parent.parent as AssignmentTreeNode;
+    const workspace = assignment.parent as WorkspaceTreeNode;
     const submissionFilePath = PdfmUtilsService.buildTreePath(submissionFile);
     this.busyService.start();
 
@@ -62,9 +62,9 @@ export class SubmissionNavigationService {
       );
   }
 
-  openSubmission(submissionFile: WorkspaceFile): Observable<any> {
-    const assignment = submissionFile.parent.parent.parent as WorkspaceAssignment;
-    const workspace = assignment.parent as Workspace;
+  openSubmission(submissionFile: WorkspaceFileTreeNode): Observable<any> {
+    const assignment = submissionFile.parent.parent.parent as AssignmentTreeNode;
+    const workspace = assignment.parent as WorkspaceTreeNode;
 
     let assignmentSettings: AssignmentSettingsInfo;
    return this.assignmentService.getAssignmentSettings(workspace.name, assignment.name)
@@ -77,7 +77,7 @@ export class SubmissionNavigationService {
             return this.convertFile(submissionFile);
           }
         }),
-        tap((submissionWorkspaceFile: WorkspaceFile) => {
+        tap((submissionWorkspaceFile: WorkspaceFileTreeNode) => {
           const pdfPath = PdfmUtilsService.buildTreePath(submissionWorkspaceFile);
           this.assignmentService.selectSubmission({
             workspace,

--- a/src/app/services/workspace.service.ts
+++ b/src/app/services/workspace.service.ts
@@ -2,7 +2,7 @@ import {Injectable} from '@angular/core';
 import {first, map, Observable, ReplaySubject, tap, throwError} from 'rxjs';
 import {WorkspaceIpcService} from '@shared/ipc/workspace.ipc-service';
 import {fromIpcResponse} from './ipc.utils';
-import {Workspace} from '@shared/info-objects/workspace';
+import {WorkspaceTreeNode} from '@shared/info-objects/workspaceTreeNode';
 import {SelectedSubmission} from '../info-objects/selected-submission';
 import {catchError} from 'rxjs/operators';
 import {find, isNil} from 'lodash';
@@ -17,7 +17,7 @@ export class WorkspaceService {
   private workspaceApi: WorkspaceIpcService;
 
 
-  public readonly workspaceList = new ReplaySubject<Workspace[]>(1);
+  public readonly workspaceList = new ReplaySubject<WorkspaceTreeNode[]>(1);
   workspaceListLoading = new ReplaySubject<boolean>(1);
 
   constructor(private appService: AppService) {
@@ -30,7 +30,7 @@ export class WorkspaceService {
   /**
    * Refresh workspaces from cache
    */
-  refreshWorkspaces(): Observable<Workspace[]> {
+  refreshWorkspaces(): Observable<WorkspaceTreeNode[]> {
     this.workspaceListLoading.next(true);
     return fromIpcResponse(this.workspaceApi.getAssignments())
       .pipe(
@@ -50,7 +50,7 @@ export class WorkspaceService {
 
 
 
-  getWorkspaceHierarchy(workspaceName: string): Observable<Workspace> {
+  getWorkspaceHierarchy(workspaceName: string): Observable<WorkspaceTreeNode> {
     if (isNil(workspaceName)) {
       workspaceName = DEFAULT_WORKSPACE;
     }

--- a/src/shared/constants/constants.ts
+++ b/src/shared/constants/constants.ts
@@ -38,6 +38,10 @@ export const SUBMISSION_ZIP_ENTRY_REGEX = new RegExp('(.*)\\/Submission attachme
 
 export const PDFM_FILES = [MARK_FILE, SETTING_FILE];
 
+export const DEFAULT_MARKS = {
+  FULL: 1,
+  INCORRECT: 0
+};
 
 export function uuidv4() {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {

--- a/src/shared/constants/constants.ts
+++ b/src/shared/constants/constants.ts
@@ -1,4 +1,4 @@
-import {TreeNode, TreeNodeType} from '@shared/info-objects/workspace';
+import {TreeNode, TreeNodeType} from '@shared/info-objects/workspaceTreeNode';
 
 export const DEFAULT_COLOR = '#6f327a';
 export const DEFAULT_WORKSPACE = 'Default Workspace';

--- a/src/shared/info-objects/workspaceTreeNode.ts
+++ b/src/shared/info-objects/workspaceTreeNode.ts
@@ -17,40 +17,40 @@ export interface TreeNode {
   children?: TreeNode[];
 }
 
-export interface Workspace extends TreeNode {
+export interface WorkspaceTreeNode extends TreeNode {
   type: TreeNodeType.WORKSPACE;
-  children: WorkspaceAssignment[];
+  children: AssignmentTreeNode[];
   parent: null;
 }
 
-export interface WorkspaceAssignment extends TreeNode {
+export interface AssignmentTreeNode extends TreeNode {
   type: TreeNodeType.ASSIGNMENT;
-  children: (WorkspaceFile| StudentSubmission)[];
-  parent: Workspace;
+  children: (WorkspaceFileTreeNode| StudentSubmissionTreeNode)[];
+  parent: WorkspaceTreeNode;
 }
 
-export interface WorkspaceFile extends TreeNode {
+export interface WorkspaceFileTreeNode extends TreeNode {
   type: TreeNodeType.FILE;
 }
 
-export interface SubmissionAttachments extends TreeNode {
+export interface SubmissionAttachmentsTreeNode extends TreeNode {
   type: TreeNodeType.SUBMISSIONS_DIRECTORY;
-  children: WorkspaceFile[];
-  parent: StudentSubmission;
+  children: WorkspaceFileTreeNode[];
+  parent: StudentSubmissionTreeNode;
 }
 
-export interface FeedbackAttachments extends TreeNode {
+export interface FeedbackAttachmentsTreeNode extends TreeNode {
   type: TreeNodeType.FEEDBACK_DIRECTORY;
-  children: WorkspaceFile[];
-  parent: StudentSubmission;
+  children: WorkspaceFileTreeNode[];
+  parent: StudentSubmissionTreeNode;
 }
 
-export interface StudentSubmission extends TreeNode {
+export interface StudentSubmissionTreeNode extends TreeNode {
   studentName: string;
   studentSurname: string;
   studentId: string;
-  children: (WorkspaceFile|SubmissionAttachments|FeedbackAttachments)[];
-  parent: WorkspaceAssignment;
+  children: (WorkspaceFileTreeNode|SubmissionAttachmentsTreeNode|FeedbackAttachmentsTreeNode)[];
+  parent: AssignmentTreeNode;
 }
 
 export function findTreeNode(path: string, roots: TreeNode[]): TreeNode {

--- a/src/shared/ipc/assignment.ipc-service.ts
+++ b/src/shared/ipc/assignment.ipc-service.ts
@@ -9,10 +9,10 @@ export interface AssignmentIpcService {
 
   createAssignment(createAssignmentInfo: AssignmentInfo): Promise<IpcResponse<any>>;
   updateAssignment(updateRequest: AssignmentInfo): Promise<IpcResponse<any>>;
-  saveMarks(location: string, marks: SubmissionInfo): Promise<IpcResponse<any>>;
+  saveMarks(workspaceName: string, assignmentName: string, studentId: string, marks: SubmissionInfo): Promise<IpcResponse<any>>;
   finalizeAssignment(workspaceFolder: string, assignmentName: string, zipFilePath: string): Promise<IpcResponse<string>>;
   getAssignmentSettings(workspaceName: string, location: string): Promise<IpcResponse<any>>;
-  getMarks(location: string): Promise<IpcResponse<SubmissionInfo>>;
+  getMarks(workspaceName: string, assignmentName: string, studentId: string): Promise<IpcResponse<SubmissionInfo>>;
   updateAssignmentSettings(updatedSettings: any, workspaceName: string, assignmentName: string): Promise<IpcResponse<any>>;
   exportAssignment(exportAssignmentsRequest: ExportAssignmentsRequest): Promise<IpcResponse<string>>;
   updateAssignmentRubric(workspaceName: string, assignmentName: string, rubricName: string): Promise<IpcResponse<IRubric>>;

--- a/src/shared/ipc/import.ipc-service.ts
+++ b/src/shared/ipc/import.ipc-service.ts
@@ -1,6 +1,6 @@
 import {IpcResponse} from './ipc-response';
 import {ImportInfo} from '../info-objects/import.info';
-import {TreeNode} from '@shared/info-objects/workspace';
+import {TreeNode} from '@shared/info-objects/workspaceTreeNode';
 import {AssignmentValidateResultInfo} from '@shared/info-objects/assignment-validate-result.info';
 import {LectureImportInfo} from '@shared/info-objects/lecture-import.info';
 import {AssignmentSettingsInfo} from '@shared/info-objects/assignment-settings.info';

--- a/src/shared/ipc/workspace.ipc-service.ts
+++ b/src/shared/ipc/workspace.ipc-service.ts
@@ -1,8 +1,8 @@
 import {IpcResponse} from './ipc-response';
-import {Workspace} from '@shared/info-objects/workspace';
+import {WorkspaceTreeNode} from '@shared/info-objects/workspaceTreeNode';
 
 export interface WorkspaceIpcService {
-  getAssignments(): Promise<IpcResponse<Workspace[]>>;
+  getAssignments(): Promise<IpcResponse<WorkspaceTreeNode[]>>;
   createWorkingFolder(name: string): Promise<IpcResponse<string>>;
   updateWorkspaceName(workspaceName: string, newWorkspaceName: string): Promise<IpcResponse<string>>;
   moveWorkspaceAssignments(currentWorkspaceName: string, workspaceName: string, assignments: any[]): Promise<IpcResponse<any>>;


### PR DESCRIPTION
- Marker name is shown
- Current mark shown and updated as you mark
- Preview marks moved to top bar
- Fixed preview marks not showing student details (since v3)
- Fixed decimal mark being lost on mark with comment
- Refactor services to save/get marks to make use of `workspace`, `assignment`, `studentId` pattern
- A lot of refactoring of events
- Rename `TreeNode` subclasses to include `*TreeNode` in their name to avoid ambiguity 