### PR TITLE
NAM-354 Fixes

### DIFF
--- a/src-electron/ipc/assignment.handler.ts
+++ b/src-electron/ipc/assignment.handler.ts
@@ -381,9 +381,8 @@ export function getAssignmentSettings(
 export function writeAssignmentSettingsAt(
   assignmentSettings: AssignmentSettingsInfo,
   assignmentAbsolutePath: string): Promise<AssignmentSettingsInfo> {
-  const buffer = new Uint8Array(Buffer.from(JSON.stringify(assignmentSettings)));
 
-  return writeFile(assignmentAbsolutePath + sep + SETTING_FILE, buffer).then(() => {
+  return writeFile(assignmentAbsolutePath + sep + SETTING_FILE, JSON.stringify(assignmentSettings)).then(() => {
     return assignmentSettings;
   }, () => {
     return Promise.reject('Failed to save assignment settings!');

--- a/src-electron/ipc/import.handler.ts
+++ b/src-electron/ipc/import.handler.ts
@@ -1,6 +1,6 @@
 import {createWriteStream, existsSync, mkdirSync} from 'fs';
 import * as glob from 'glob';
-import {basename, dirname, sep} from 'path';
+import {basename, dirname, extname, sep} from 'path';
 import {
   AssignmentSettingsInfo,
   AssignmentState,
@@ -43,7 +43,7 @@ import {
   MARK_FILE,
   SETTING_FILE,
   SUBMISSION_FOLDER, SUBMISSION_ZIP_DIR_REGEX,
-  SUBMISSION_ZIP_ENTRY_REGEX,
+  SUBMISSION_ZIP_ENTRY_REGEX, SUPPORTED_SUBMISSION_EXTENSIONS,
   uuidv4
 } from '@shared/constants/constants';
 import {AssignmentValidateResultInfo, ZipFileType} from '@shared/info-objects/assignment-validate-result.info';
@@ -330,6 +330,13 @@ function extractGenericImport(
 
       const tempDetails = zipRelativePath.substring((zipRelativePath.indexOf('/') + 1));
       const splitArray = tempDetails.split('_');
+
+      // If the file is not one of the supported extensions, ignore it
+      const ext = extname(fileFullPath);
+      if (!ext.startsWith('.') || !SUPPORTED_SUBMISSION_EXTENSIONS.includes(ext.substring(1))) {
+        LOG.warn('Unknown file, ignoring... ' + zipFilePath);
+        return;
+      }
 
       const studentName = splitArray[1];
       const studentSurname = splitArray[0];

--- a/src/app/components/assignment-marking/assignment-marking.component.ts
+++ b/src/app/components/assignment-marking/assignment-marking.component.ts
@@ -263,10 +263,12 @@ export class AssignmentMarkingComponent implements OnInit, OnDestroy {
   }
 
   private onColourChanged(colour: string) {
-    this.updateAssignmentSettings({
-      ...this.assignmentSettings,
-      defaultColour: colour
-    });
+    if (this.assignmentSettings.defaultColour !== colour) {
+      this.updateAssignmentSettings({
+        ...this.assignmentSettings,
+        defaultColour: colour
+      });
+    }
   }
 
   onPagedChanged(pageNumber: number) {

--- a/src/app/components/import/import.component.ts
+++ b/src/app/components/import/import.component.ts
@@ -229,7 +229,7 @@ export class ImportComponent implements OnInit, OnDestroy {
         if (PdfmUtilsService.isDefaultWorkspace(importData.workspace)) {
           this.router.navigate([RoutesEnum.ASSIGNMENT_OVERVIEW, assignmentDirectory]);
         } else {
-          this.router.navigate([RoutesEnum.ASSIGNMENT_OVERVIEW, importData.workspace, assignmentDirectory]);
+          this.router.navigate([RoutesEnum.ASSIGNMENT_OVERVIEW, assignmentDirectory, importData.workspace]);
         }
 
       },

--- a/src/shared/constants/constants.ts
+++ b/src/shared/constants/constants.ts
@@ -30,14 +30,17 @@ export const SUPPORTED_SUBMISSION_TYPES = [{
   extensions: ['txt']
 }];
 
+export const SUPPORTED_SUBMISSION_EXTENSIONS = SUPPORTED_SUBMISSION_TYPES.flatMap(t => t.extensions);
+
 export const ASSIGNMENT_BACKUP_DIR = '.backup';
 export const FEEDBACK_ZIP_DIR_REGEX = /\/(.*)\/Feedback Attachment\(s\)\/$/;
 export const SUBMISSION_ZIP_DIR_REGEX = /\/(.*)\/Submission attachment\(s\)\/$/;
 
 export const FEEDBACK_ZIP_ENTRY_REGEX = /\/(.*)\/Feedback Attachment\(s\)\/(.*)\.pdf/;
 
-const extensions = SUPPORTED_SUBMISSION_TYPES.flatMap(t => t.extensions).join('|');
-export const SUBMISSION_ZIP_ENTRY_REGEX = new RegExp('(.*)\\/Submission attachment\\(s\\)\\/(.*)\\.(' + extensions + ')');
+
+const extensions_or = SUPPORTED_SUBMISSION_EXTENSIONS.join('|');
+export const SUBMISSION_ZIP_ENTRY_REGEX = new RegExp('(.*)\\/Submission attachment\\(s\\)\\/(.*)\\.(' + extensions_or + ')');
 
 export const PDFM_FILES = [MARK_FILE, SETTING_FILE];
 


### PR DESCRIPTION
- Fixed generic import will now ignore unknown file extensions (it does not get placed in backup)
- Fixed generic import to workspace not loading the assignment overview when importing to workspace
- Fixed race condition that caused assignment settings to sometimes not load when opening the marking view