### PR TITLE
NAM-377 Libre office archive

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -26,7 +26,7 @@ Function nsDialogsPage
 	Pop $Label
 
   ; Create a checkbox to optionally install libre office
-	${NSD_CreateCheckbox} 0 25u 100% 8u "Download and Install Libre Office 7.6"
+	${NSD_CreateCheckbox} 0 25u 100% 8u "Download and Install Libre Office 24.2"
   Pop $LibreInstallCheckbox
 
   ; Reset the checkbox state incase user went back to this page
@@ -45,9 +45,9 @@ FunctionEnd
 
   ${If} $LibreInstallCheckbox_State == ${BST_CHECKED}
     # C:\Users\USERNAME\AppData\Local\Temp
-    NScurl::http get "https://download.documentfoundation.org/libreoffice/stable/7.6.2/win/x86_64/LibreOffice_7.6.2_Win_x86-64.msi" "$TEMP\LibreOffice_7.6.2_Win_x86-64.msi" /POPUP /INSIST /Zone.Identifier /END
+    NScurl::http get "https://downloadarchive.documentfoundation.org/libreoffice/old/24.2.3.2/win/x86_64/LibreOffice_24.2.3.2_Win_x86-64.msi" "$TEMP\LibreOffice_7.6.2_Win_x86-64.msi" /POPUP /INSIST /Zone.Identifier /END
     Pop $0
-    ExecWait '"msiexec" /i "$TEMP\LibreOffice_7.6.2_Win_x86-64.msi" /passive'
+    ExecWait '"msiexec" /i "$TEMP\LibreOffice_24.2.3.2_Win_x86-64.msi" /passive'
   ${EndIf}
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdf-marker",
-  "version": "4.1.4",
+  "version": "4.1.5-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pdf-marker",
-      "version": "4.1.4",
+      "version": "4.1.5-beta.1",
       "hasInstallScript": true,
       "dependencies": {
         "@angular/animations": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-marker",
-  "version": "4.1.4",
+  "version": "4.1.5-beta.1",
   "description": "PDF Marker",
   "homepage": "https://github.com/efundi/PDF-Marker",
   "main": "main.js",

--- a/src-electron/ipc/convert.handler.ts
+++ b/src-electron/ipc/convert.handler.ts
@@ -204,7 +204,7 @@ function extractVersion(vString: string): string{
   if (isNil(vString)) {
     return null;
   } else {
-    return vString.trim().match(/(\d\.\d(\.\d)*)/)[0];
+    return vString.trim().match(/(\d+\.\d+(\.\d)*)/)[0];
   }
 }
 

--- a/src-electron/migration/assignment.migration.ts
+++ b/src-electron/migration/assignment.migration.ts
@@ -80,7 +80,7 @@ function upgradeAssignmentDirectory(assignmentFolder: string, version: number): 
     return Promise.resolve();
   }
 
-  let promise: Promise<any>;
+  let promise: Promise<any> = Promise.resolve();
   let currentVersion = version;
   if (isNil(currentVersion)) {
     const backupDir = assignmentFolder +  sep + ASSIGNMENT_BACKUP_DIR;


### PR DESCRIPTION
Updated download link to https://downloadarchive.documentfoundation.org/libreoffice/old/24.2.3.2/win/x86_64/LibreOffice_24.2.3.2_Win_x86-64.msi

Fixed installer label to say Download and Install Libre Office 24.2

Update version checker regex to capture the multi digits in the version

Bonus - Fix possible undefined exception when there are no workspace migrations